### PR TITLE
ユーザー詳細画面

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## クローン
 ```
-$ git clone -b develop git@github.com:Rihitonnnu/docker-laravel.git
+$ git clone git@github.com:Rihitonnnu/docker-laravel.git
 ```
 
 ## プロジェクトセットアップ

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -10,7 +10,7 @@ class UserController extends Controller
     /** @return \Illuminate\Contracts\View\View*/
     public function index()
     {
-        $users=User::paginate(20);
+        $users = User::paginate(20);
         return view('admin.user.index', compact('users'));
     }
 
@@ -21,7 +21,7 @@ class UserController extends Controller
      * */
     public function show($id)
     {
-        $user=User::find($id);
+        $user = User::find($id);
         return view('admin.user.show', compact('user'));
     }
 }

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -13,4 +13,15 @@ class UserController extends Controller
         $users=User::paginate(20);
         return view('admin.user.index', compact('users'));
     }
+
+    /**
+     * @return \Illuminate\Contracts\View\View
+     * @param int $id
+     *
+     * */
+    public function show($id)
+    {
+        $user=User::find($id);
+        return view('admin.user.show', compact('user'));
+    }
 }

--- a/resources/views/admin/user/index.blade.php
+++ b/resources/views/admin/user/index.blade.php
@@ -32,7 +32,7 @@
                                                 <td class="px-4 py-3 text-center w-1/4">{{ $user->name }}</td>
                                                 <td class="px-4 py-3 w-1/4">
                                                     <div class="flex pl-4 w-full mx-auto">
-                                                        <button class="flex mx-auto text-white bg-indigo-500 border-0 py-2 px-6 focus:outline-none hover:bg-indigo-600 rounded">
+                                                        <button onclick="location.href='{{route('admin.user.show',['user'=>$user->id])}}'" class="flex mx-auto text-white bg-indigo-500 border-0 py-2 px-6 focus:outline-none hover:bg-indigo-600 rounded">
                                                             詳細
                                                         </button>
                                                     </div>

--- a/resources/views/admin/user/index.blade.php
+++ b/resources/views/admin/user/index.blade.php
@@ -30,19 +30,14 @@
                                             <tr>
                                                 <td class="px-4 py-3 text-center w-1/4">{{ $user->id }}</td>
                                                 <td class="px-4 py-3 text-center w-1/4">{{ $user->name }}</td>
+
+                                                {{-- 詳細ボタン --}}
                                                 <td class="px-4 py-3 w-1/4">
-                                                    <div class="flex pl-4 w-full mx-auto">
-                                                        <button onclick="location.href='{{route('admin.user.show',['user'=>$user->id])}}'" class="flex mx-auto text-white bg-indigo-500 border-0 py-2 px-6 focus:outline-none hover:bg-indigo-600 rounded">
-                                                            詳細
-                                                        </button>
-                                                    </div>
+                                                    <x-anchor-button route="{{ route('admin.user.show',['user'=>$user->id]) }}" title="詳細" color="indigo" />
                                                 </td>
+                                                {{-- 削除ボタン --}}
                                                 <td class="px-4 py-3 w-1/4">
-                                                    <div class="flex pl-4 w-full mx-auto">
-                                                        <button class="flex mx-auto text-white bg-red-500 border-0 py-2 px-6 focus:outline-none hover:bg-red-600 rounded">
-                                                            削除
-                                                        </button>
-                                                    </div>
+                                                    <x-anchor-button route="" title="削除" color="red" />
                                                 </td>
                                             </tr>
                                         </tbody>

--- a/resources/views/admin/user/show.blade.php
+++ b/resources/views/admin/user/show.blade.php
@@ -1,0 +1,48 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            ユーザー詳細
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-5xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+
+                    <section class="text-gray-600 body-font relative">
+                        <div class="container px-5 py-6 mx-auto">
+                            <div class="lg:w-1/2 md:w-2/3 mx-auto">
+                                <div class="flex flex-wrap -m-2">
+                                    <div class="p-2 w-full">
+                                        <div class="relative">
+                                            <label for="name" class="leading-7 text-sm text-gray-600">名前</label>
+                                            <input value="{{$user->name}}" type="text" id="name" name="name" disabled class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                                        </div>
+                                    </div>
+                                    <div class="p-2 w-full">
+                                        <div class="relative">
+                                            <label for="email" class="leading-7 text-sm text-gray-600">メールアドレス</label>
+                                            <input value="{{$user->email}}" type="email" id="email" name="email" disabled class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                                        </div>
+                                    </div>
+                                    <div class="p-2 w-full">
+                                        <div class="relative">
+                                            <label for="created_at" class="leading-7 text-sm text-gray-600">アカウント作成日</label>
+                                            <input value="{{\Carbon\Carbon::parse($user->created_at)->toDateString()}}" type="text" id="created_at" name="created_at" disabled class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                                        </div>
+                                    </div>
+
+                                    {{-- 戻るボタン --}}
+                                    <div class="p-2 w-full mt-5">
+                                        <button onclick="location.href='{{ route('admin.user.index') }}'" class="flex mx-auto text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">戻る</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/user/show.blade.php
+++ b/resources/views/admin/user/show.blade.php
@@ -10,37 +10,43 @@
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 bg-white border-b border-gray-200">
 
-                    <section class="text-gray-600 body-font relative">
-                        <div class="container px-5 py-6 mx-auto">
-                            <div class="lg:w-1/2 md:w-2/3 mx-auto">
-                                <div class="flex flex-wrap -m-2">
-                                    <div class="p-2 w-full">
-                                        <div class="relative">
-                                            <label for="name" class="leading-7 text-sm text-gray-600">名前</label>
-                                            <input value="{{$user->name}}" type="text" id="name" name="name" disabled class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
-                                        </div>
-                                    </div>
-                                    <div class="p-2 w-full">
-                                        <div class="relative">
-                                            <label for="email" class="leading-7 text-sm text-gray-600">メールアドレス</label>
-                                            <input value="{{$user->email}}" type="email" id="email" name="email" disabled class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
-                                        </div>
-                                    </div>
-                                    <div class="p-2 w-full">
-                                        <div class="relative">
-                                            <label for="created_at" class="leading-7 text-sm text-gray-600">アカウント作成日</label>
-                                            <input value="{{\Carbon\Carbon::parse($user->created_at)->toDateString()}}" type="text" id="created_at" name="created_at" disabled class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
-                                        </div>
-                                    </div>
-
-                                    {{-- 戻るボタン --}}
-                                    <div class="p-2 w-full mt-5">
-                                        <button onclick="location.href='{{ route('admin.user.index') }}'" class="flex mx-auto text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">戻る</button>
-                                    </div>
+                    <table class="table-auto w-full text-left whitespace-no-wrap mb-4">
+                            <tr class="border-2 border-gray-300">
+                                <div class="flex">
+                                    <th class="w-1/6 text-center px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100 rounded-tl rounded-bl">
+                                        ID
+                                    </th>
+                                    <td class="px-4 py-3 text-center w-1/4">{{ $user->id }}</td>
                                 </div>
-                            </div>
-                        </div>
-                    </section>
+                            </tr>
+                            <tr class="border-2 border-gray-300">
+                                <div class="flex">
+                                    <th class="w-1/6 text-center px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">
+                                        名前
+                                    </th>
+                                    <td class="px-4 py-3 text-center w-1/4">{{ $user->name }}</td>
+                                </div>
+                            </tr>
+                            <tr class="border-2 border-gray-300">
+                                <div class="flex">
+                                    <th class="w-1/6 text-center px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">
+                                        メールアドレス
+                                    </th>
+                                    <td class="px-4 py-3 text-center w-1/4">{{ $user->email }}</td>
+                                </div>
+                            </tr>
+                            <tr class="border-2 border-gray-300">
+                                <div class="flex">
+                                    <th class="w-1/6 text-center px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">
+                                        アカウント作成日
+                                    </th>
+                                    <td class="px-4 py-3 text-center w-1/4">{{ \Carbon\Carbon::parse($user->created_at)->toDateString() }}</td>
+                                </div>
+                            </tr>
+                    </table>
+
+                    {{-- 戻るボタン --}}
+                    <x-anchor-button route="{{ route('admin.user.index') }}" title="戻る" color="indigo" />
                 </div>
             </div>
         </div>

--- a/resources/views/components/anchor-button.blade.php
+++ b/resources/views/components/anchor-button.blade.php
@@ -1,0 +1,3 @@
+<div class="flex pl-4 w-full mx-auto">
+    <a href="{{ $route }}" class="flex mx-auto text-white bg-{{ $color }}-500 border-0 py-2 px-6 focus:outline-none hover:bg-{{ $color }}-600 rounded">{{ $title }}</a>
+</div>


### PR DESCRIPTION
## 今回のPRで行ったこと
- README編集
  - 削除したdevelopブランチをクローンする仕様になっていたのでmainブランチをクローンするように変更しました
- ユーザー詳細画面作成(管理者側)
 

## UIの変更点
### ユーザー一覧画面の詳細ボタンから遷移
![index_show_button](https://user-images.githubusercontent.com/69156872/196021231-9158fa12-2d79-45aa-bc4c-12f336c7791f.jpg)


### ユーザー詳細画面
<img width="937" alt="image" src="https://user-images.githubusercontent.com/69156872/196021024-7655de04-c7fd-4d01-a6ac-179c8526ad3c.png">
