### PR TITLE
投稿作成(ユーザー側)

### DIFF
--- a/app/Http/Controllers/User/ArticleController.php
+++ b/app/Http/Controllers/User/ArticleController.php
@@ -3,11 +3,19 @@
 namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\User\Article\PostRequest;
 use App\Models\Article;
 use Illuminate\Support\Facades\Auth;
 
 class ArticleController extends Controller
 {
+    private Article $article;
+
+    public function __construct(Article $article)
+    {
+        $this->article = $article;
+    }
+
     /**
      * @return \Illuminate\Contracts\View\View
      */

--- a/app/Http/Controllers/User/ArticleController.php
+++ b/app/Http/Controllers/User/ArticleController.php
@@ -23,4 +23,29 @@ class ArticleController extends Controller
     {
         return view('user.article.index', ['articles' => Article::where('user_id', Auth::id())->get()]);
     }
+
+    /**
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function create()
+    {
+        return view('user.article.create');
+    }
+
+    /**
+     * @param PostRequest $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function store(PostRequest $request)
+    {
+        /** @var int $userId */
+        $userId = Auth::id();
+        /** @var string $title */
+        $title = $request->title;
+        /** @var string $content */
+        $content = $request->content;
+
+        $this->article->storeArticle($userId, $title, $content);
+        return to_route('user.article.index');
+    }
 }

--- a/app/Http/Controllers/User/ArticleController.php
+++ b/app/Http/Controllers/User/ArticleController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\User\Article\PostRequest;
+use App\Http\Requests\User\Article\CreateRequest;
 use App\Models\Article;
 use Illuminate\Support\Facades\Auth;
 
@@ -33,10 +33,10 @@ class ArticleController extends Controller
     }
 
     /**
-     * @param PostRequest $request
+     * @param CreateRequest $request
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function store(PostRequest $request)
+    public function store(CreateRequest $request)
     {
         /** @var int $userId */
         $userId = Auth::id();

--- a/app/Http/Requests/User/Article/CreateRequest.php
+++ b/app/Http/Requests/User/Article/CreateRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests\User\Article;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class PostRequest extends FormRequest
+class CreateRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -24,7 +24,7 @@ class PostRequest extends FormRequest
     public function rules()
     {
         return [
-            'title' => 'required|unique:articles|max:50',
+            'title' => 'required|max:50',
             'content' => 'required|max:1000',
             'created_at' => 'nullable|date',
         ];

--- a/app/Http/Requests/User/Article/CreateRequest.php
+++ b/app/Http/Requests/User/Article/CreateRequest.php
@@ -26,7 +26,6 @@ class CreateRequest extends FormRequest
         return [
             'title' => 'required|max:50',
             'content' => 'required|max:1000',
-            'created_at' => 'nullable|date',
         ];
     }
 
@@ -34,7 +33,6 @@ class CreateRequest extends FormRequest
     {
         return [
             'title.required' => 'タイトルを入力して下さい',
-            'title.unique' => 'タイトルが重複しているので変更してください',
             'title.max' => 'タイトルは50文字以内で入力してください',
             'content.required' => '本文を入力して下さい',
             'content.max' => '本文は1000文字以内で入力してください',

--- a/app/Http/Requests/User/Article/PostRequest.php
+++ b/app/Http/Requests/User/Article/PostRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\User\Article;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|unique:articles|max:50',
+            'content' => 'required|max:1000',
+            'created_at' => 'nullable|date',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'title.required' => 'タイトルを入力して下さい',
+            'title.unique' => 'タイトルが重複しているので変更してください',
+            'title.max' => 'タイトルは50文字以内で入力してください',
+            'content.required' => '本文を入力して下さい',
+            'content.max' => '本文は1000文字以内で入力してください',
+        ];
+    }
+}

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -30,11 +29,10 @@ class Article extends Model
      */
     public function storeArticle(int $userId, string $title, string $content)
     {
-        $article = $this::create([
+        $article = $this->create([
             'user_id' => $userId,
             'title' => $title,
             'content' => $content,
-            'created_at' => Carbon::now(),
         ]);
         return $article;
     }

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -20,6 +21,23 @@ class Article extends Model
         'title',
         'content',
     ];
+
+    /**
+     * @return \App\Models\Article
+     * @param int $userId
+     * @param string $title
+     * @param string $content
+     */
+    public function storeArticle(int $userId, string $title, string $content)
+    {
+        $article = $this::create([
+            'user_id' => $userId,
+            'title' => $title,
+            'content' => $content,
+            'created_at' => Carbon::now(),
+        ]);
+        return $article;
+    }
 
     public function user(): BelongsTo
     {

--- a/resources/views/components/text-input.blade.php
+++ b/resources/views/components/text-input.blade.php
@@ -1,3 +1,2 @@
-@props(['disabled' => false])
+<input id={{$id}} name={{$name}} {!! $attributes->merge(['class' => 'w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out']) !!}>
 
-<input {{ $disabled ? 'disabled' : '' }} {!! $attributes->merge(['class' => 'rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50']) !!}>

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -1,0 +1,1 @@
+<textarea id={{ $id }} name={{ $name }} class="w-full h-72 whitespace-pre-wrap bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 resize-none leading-6 transition-colors duration-200 ease-in-out"></textarea>

--- a/resources/views/layouts/user-navigation.blade.php
+++ b/resources/views/layouts/user-navigation.blade.php
@@ -18,6 +18,9 @@
                     <x-nav-link :href="route('user.article.index')" :active="request()->routeIs('user.article.index')">
                         自分の投稿一覧
                     </x-nav-link>
+                    <x-nav-link :href="route('user.article.create')" :active="request()->routeIs('user.article.create')">
+                        記事を投稿する
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -50,7 +53,7 @@
 
             <!-- Hamburger -->
             <div class="-mr-2 flex items-center sm:hidden">
-                <button @click="open = ! open"
+                <button @click="open = ! open" 
                     class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
                     <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
                         <path :class="{ 'hidden': open, 'inline-flex': !open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
@@ -69,6 +72,9 @@
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('user.article.index')" :active="request()->routeIs('user.article.index')">
                 自分の投稿一覧
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('user.article.create')" :active="request()->routeIs('user.article.create')">
+                記事を投稿する
             </x-responsive-nav-link>
         </div>
 

--- a/resources/views/user/article/create.blade.php
+++ b/resources/views/user/article/create.blade.php
@@ -1,0 +1,58 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            投稿作成画面
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+
+                    <form action="{{ route('user.article.store') }}" method="POST">
+                        @csrf
+                        <section class="text-gray-600 body-font relative w-full">
+                            <div class="py-8">
+                                <div class="lg:w-2/3 md:w-5/6 mx-auto">
+                                    <div class="flex flex-wrap -m-2">
+                                        <div class="p-2 w-full">
+                                            <div class="relative">
+                                                <div class="flex">
+                                                    <label for="title" class="leading-7 text-sm text-gray-600">タイトル</label>
+                                                    @if ($errors->has('title'))
+                                                        <ul>
+                                                            <li class="text-red-500 ml-4 mt-1 text-sm">{{$errors->first('title')}}</li>
+                                                        </ul>
+                                                    @endif
+                                                </div>
+                                                <input type="text" id="title" name="title" value="{{ old('title') }}" class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                                            </div>
+                                        </div>
+                                        <div class="p-2 w-full">
+                                            <div class="relative">
+                                                <div class="flex">
+                                                    <label for="content" class="leading-7 text-sm text-gray-600">本文</label>
+                                                    @if ($errors->has('content'))
+                                                        <ul>
+                                                            <li class="text-red-500 ml-4 mt-1 text-sm">{{$errors->first('content')}}</li>
+                                                        </ul>
+                                                    @endif
+                                                </div>
+                                                <textarea id="content" name="content" class="w-full whitespace-pre-wrap bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 h-32 text-base outline-none text-gray-700 py-1 px-3 resize-none leading-6 transition-colors duration-200 ease-in-out">{{ old('content') }}</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="p-2 w-full">
+                                            <x-submit-button title="投稿する" class="bg-indigo-500 hover:bg-indigo-600" />
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+                    </form>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/user/article/create.blade.php
+++ b/resources/views/user/article/create.blade.php
@@ -26,7 +26,7 @@
                                                         </ul>
                                                     @endif
                                                 </div>
-                                                <input type="text" id="title" name="title" value="{{ old('title') }}" class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                                                <x-text-input id="title" name="title" value="{{ old('title') }}"/>
                                             </div>
                                         </div>
                                         <div class="p-2 w-full">
@@ -39,7 +39,7 @@
                                                         </ul>
                                                     @endif
                                                 </div>
-                                                <textarea id="content" name="content" class="w-full h-72 whitespace-pre-wrap bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 resize-none leading-6 transition-colors duration-200 ease-in-out">{{ old('content') }}</textarea>
+                                                <x-textarea id="content" name="content">{{ old('content') }}</x-textarea>
                                             </div>
                                         </div>
                                         <div class="p-2 w-full">

--- a/resources/views/user/article/create.blade.php
+++ b/resources/views/user/article/create.blade.php
@@ -39,7 +39,7 @@
                                                         </ul>
                                                     @endif
                                                 </div>
-                                                <textarea id="content" name="content" class="w-full whitespace-pre-wrap bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 h-32 text-base outline-none text-gray-700 py-1 px-3 resize-none leading-6 transition-colors duration-200 ease-in-out">{{ old('content') }}</textarea>
+                                                <textarea id="content" name="content" class="w-full h-72 whitespace-pre-wrap bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 resize-none leading-6 transition-colors duration-200 ease-in-out">{{ old('content') }}</textarea>
                                             </div>
                                         </div>
                                         <div class="p-2 w-full">

--- a/tests/Feature/User/ArticleControllerTest.php
+++ b/tests/Feature/User/ArticleControllerTest.php
@@ -41,4 +41,45 @@ class ArticleControllerTest extends TestCase
         $response = $this->get(route('user.article.index'));
         $response->assertRedirect(route('user.login'));
     }
+
+    /**
+     * @test
+     */
+    public function ログインしていれば投稿作成画面へリダイレクトする()
+    {
+        $this->actingAs($this->user, 'users');
+
+        $response = $this->get(route('user.article.create'));
+        $response->assertStatus(200);
+    }
+
+    /**
+     * @test
+     */
+    public function ログインしていない状態で投稿作成画面を表示する時ログイン画面へリダイレクトする()
+    {
+        $response = $this->get(route('user.article.create'));
+        $response->assertRedirect(route('user.login'));
+    }
+
+    /**
+     * @test
+     */
+    public function ログインしていれば新規投稿内容の保存を行う()
+    {
+        $this->actingAs($this->user, 'users');
+
+        $response = $this->post(route('user.article.store'));
+        $response = $this->get(route('user.article.index'));
+        $response->assertStatus(200);
+    }
+
+    /**
+     * @test
+     */
+    public function ログインしていない状態で新規投稿内容の保存を行う場合ログイン画面へリダイレクトする()
+    {
+        $response = $this->post(route('user.article.store'));
+        $response->assertRedirect(route('user.login'));
+    }
 }

--- a/tests/Feature/User/ArticleControllerTest.php
+++ b/tests/Feature/User/ArticleControllerTest.php
@@ -69,9 +69,8 @@ class ArticleControllerTest extends TestCase
     {
         $this->actingAs($this->user, 'users');
 
-        $response = $this->post(route('user.article.store'));
-        $response = $this->get(route('user.article.index'));
-        $response->assertStatus(200);
+        $response = $this->from(route('user.article.index'))->post(route('user.article.store'));
+        $response->assertRedirect(route('user.article.index'));
     }
 
     /**

--- a/tests/Feature/User/ArticleControllerTest.php
+++ b/tests/Feature/User/ArticleControllerTest.php
@@ -69,7 +69,10 @@ class ArticleControllerTest extends TestCase
     {
         $this->actingAs($this->user, 'users');
 
-        $response = $this->from(route('user.article.index'))->post(route('user.article.store'));
+        $response = $this->post(route('user.article.store', [
+            'title' => "ほげほげ",
+            'content' => "ふがふが",
+        ]));
         $response->assertRedirect(route('user.article.index'));
     }
 

--- a/tests/Unit/Models/ArticleTest.php
+++ b/tests/Unit/Models/ArticleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Article;
+use App\Models\User;
+use Tests\TestCase;
+
+class ArticleTest extends TestCase
+{
+    protected function setup(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['id' => 1]);
+    }
+
+    public function test_storeArticle()
+    {
+        $storeArticle = (new Article())->storeArticle($this->user->id, 'ほげほげ', 'ふがふが');
+
+        $this->assertEquals($this->user->id, $storeArticle->user_id);
+        $this->assertEquals('ほげほげ', $storeArticle->title);
+        $this->assertEquals('ふがふが', $storeArticle->content);
+    }
+}

--- a/tests/Unit/Models/ArticleTest.php
+++ b/tests/Unit/Models/ArticleTest.php
@@ -11,15 +11,15 @@ class ArticleTest extends TestCase
     protected function setup(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create(['id' => 1]);
+        $this->user = User::factory()->create();
     }
 
     public function test_storeArticle()
     {
-        $storeArticle = (new Article())->storeArticle($this->user->id, 'ほげほげ', 'ふがふが');
+        $article = (new Article())->storeArticle($this->user->id, 'ほげほげ', 'ふがふが');
 
-        $this->assertEquals($this->user->id, $storeArticle->user_id);
-        $this->assertEquals('ほげほげ', $storeArticle->title);
-        $this->assertEquals('ふがふが', $storeArticle->content);
+        $this->assertEquals($this->user->id, $article->user_id);
+        $this->assertEquals('ほげほげ', $article->title);
+        $this->assertEquals('ふがふが', $article->content);
     }
 }

--- a/tests/Unit/Requests/Admin/User/UpdateRequestTest.php
+++ b/tests/Unit/Requests/Admin/User/UpdateRequestTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Unit\Requests\Admin\User;
+
+use App\Http\Requests\Admin\User\UpdateRequest;
+use Tests\TestCase;
+use Illuminate\Support\Facades\Validator;
+
+
+class UpdateRequestTest extends TestCase
+{
+    /**
+     * ユーザー情報更新のテストデータ
+     * @return array
+     */
+    public function dataProviderUpdate()
+    {
+        return [
+            '正常データ' => [
+                'data' => [
+                    'name' => 'hoge',
+                    'email' => 'hoge@test.com',
+                ],
+                true,
+                'errors' => [],
+            ],
+            '空配列' => [
+                'data' => [],
+                false,
+                'errors' => [
+                    'name' => [
+                        '名前を入力して下さい'
+                    ],
+                    'email' => [
+                        'メールアドレスを入力して下さい'
+                    ],
+                ]
+            ],
+            'メールアドレス異常' => [
+                'data' => [
+                    'name' => 'hoge',
+                    'email' => 'hoge',
+                ],
+                false,
+                'errors' => [
+                    'email' => [
+                        '適切なメールアドレスを入力してください'
+                    ],
+                ],
+            ],
+            'マルチバイトメールアドレス' => [
+                'data' => [
+                    'name' => 'hoge',
+                    'email' => 'hoge@test.comあいうえお',
+                ],
+                false,
+                'errors' => [
+                    'email' => [
+                        '適切なメールアドレスを入力してください'
+                    ],
+                ],
+            ]
+        ];
+    }
+
+    protected function setup(): void
+    {
+        parent::setUp();
+        $this->updateRequest = new UpdateRequest();
+    }
+
+    /**
+     * ユーザー更新
+     * @test
+     * @param array $data
+     * @param boolean $expect
+     * @param array $errors
+     * @return void
+     * @dataProvider dataProviderUpdate
+     */
+    public function testUpdateValidation(array $data, bool $expect, array $errors): void
+    {
+        $validator = Validator::make($data, $this->updateRequest->rules(), $this->updateRequest->messages());
+        $this->assertEquals($expect, $validator->passes()); //バリデーションのチェックが通ったかどうか
+        $this->assertEquals($errors, $validator->errors()->getMessages()); //エラーメッセージチェック
+    }
+}

--- a/tests/Unit/Requests/User/Article/CreateRequestTest.php
+++ b/tests/Unit/Requests/User/Article/CreateRequestTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit\Requests\User\Article;
+
+use App\Http\Requests\User\Article\CreateRequest;
+use Faker\Factory;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class CreateRequestTest extends TestCase
+{
+    /**
+     * 投稿作成のテストデータ
+     * @return array
+     */
+    public function dataProviderCreate()
+    {
+        return [
+            '正常データ' => [
+                'data' => [
+                    'title' => 'ほげほげ',
+                    'content' => 'ふがふが',
+                ],
+                true,
+                'errors' => [],
+            ],
+            '空配列' => [
+                'data' => [],
+                false,
+                'errors' => [
+                    'title' => [
+                        'タイトルを入力して下さい'
+                    ],
+                    'content' => [
+                        '本文を入力して下さい'
+                    ],
+                ]
+            ],
+            '文字数上限' => [
+                'data' => [
+                    'title' => Factory::create()->realText(100),
+                    'content' => Factory::create()->realText(1200),
+                ],
+                false,
+                'errors' => [
+                    'title' => [
+                        'タイトルは50文字以内で入力してください'
+                    ],
+                    'content' => [
+                        '本文は1000文字以内で入力してください'
+                    ],
+                ]
+            ],
+        ];
+    }
+
+    protected function setup(): void
+    {
+        parent::setUp();
+        $this->createRequest = new CreateRequest();
+    }
+
+    /**
+     * 新規投稿の作成
+     * @test
+     * @param array $data
+     * @param boolean $expect
+     * @param array $errors
+     * @dataProvider dataProviderCreate
+     * @return void
+     */
+    public function testCreateValidation(array $data, bool $expect, array $errors): void
+    {
+        $validator = Validator::make($data, $this->createRequest->rules(), $this->createRequest->messages());
+        $this->assertEquals($expect, $validator->passes()); //バリデーションのチェックが通ったかどうか
+        $this->assertEquals($errors, $validator->errors()->getMessages()); //エラーメッセージテスト
+    }
+}


### PR DESCRIPTION
## 今回のPRで行っていること
- 投稿作成機能の実装
  - 投稿処理のレスポンスやDB保存のテスト作成
  - 投稿フォームのバリデーションを行うPostRequest.phpの作成

## 次回のPRで行うこと
- 投稿の詳細表示機能の実装

## UI変更点
### 新規追加

投稿作成画面
<img width="723" alt="image" src="https://user-images.githubusercontent.com/69156872/200553581-d1e6257a-b317-43ed-b267-820b1200a711.png">


