### PR TITLE
投稿詳細画面(ユーザー側)

### DIFF
--- a/app/Http/Controllers/User/ArticleController.php
+++ b/app/Http/Controllers/User/ArticleController.php
@@ -48,4 +48,13 @@ class ArticleController extends Controller
         $this->article->storeArticle($userId, $title, $content);
         return to_route('user.article.index');
     }
+
+    /**
+     * @param int $id
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function show(int $id)
+    {
+        return view('user.article.show', ['article' => Article::find($id),]);
+    }
 }

--- a/resources/views/user/article/index.blade.php
+++ b/resources/views/user/article/index.blade.php
@@ -13,7 +13,7 @@
                     @foreach($articles as $article)
                     <section class="text-gray-600 body-font overflow-hidden border-b-2 border-gray-200">
                         <div class="container px-10 pt-8 mx-auto">
-                            <a href="" class="-my-8">
+                            <a href="{{ route('user.article.show',['article'=>$article->id]) }}" class="-my-8">
                                 <div class="py-4 flex flex-wrap md:flex-nowrap">
                                     <div class="md:flex-grow">
                                         <h2 class="text-2xl font-medium text-gray-900 title-font mb-2">{{ $article->title }}</h2>

--- a/resources/views/user/article/show.blade.php
+++ b/resources/views/user/article/show.blade.php
@@ -1,0 +1,35 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            記事詳細画面
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <section class="text-gray-600 body-font">
+                        <div class="container mx-auto flex flex-col">
+                            <div class="lg:w-full mx-auto">
+                                <div class="flex flex-col sm:flex-row mt-10">
+                                    <div class="w-full sm:pl-8 border-gray-200 sm:border-t-0 border-t mt-4 pt-4 sm:mt-0 text-center sm:text-left">
+                                        <h1 class="font-bold text-3xl text-black">{{ $article->title }}</h1>
+                                        <p class="text-sm mt-1">投稿日時 {{ $article->created_at }}</p>
+                                        <div class="mt-4">
+                                            {{-- 改行した状態で内容を表示するためエスケープ処理を無効化 --}}
+                                            <p class="leading-relaxed text-md mb-4">{!!nl2br($article->content) !!}</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                    <div class="mx-auto w-32 mt-6">
+                        <x-anchor-button route="{{ route('user.article.index') }}" title="一覧へ戻る" class="bg-indigo-500 hover:bg-indigo-600" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/user/article/show.blade.php
+++ b/resources/views/user/article/show.blade.php
@@ -18,7 +18,7 @@
                                         <p class="text-sm mt-1">投稿日時 {{ $article->created_at }}</p>
                                         <div class="mt-4">
                                             {{-- 改行した状態で内容を表示するためエスケープ処理を無効化 --}}
-                                            <p class="leading-relaxed text-md mb-4">{!!nl2br($article->content) !!}</p>
+                                            <p class="leading-relaxed text-md mb-4">{!!nl2br(htmlspecialchars($article->content)) !!}</p>
                                         </div>
                                     </div>
                                 </div>

--- a/tests/Feature/User/ArticleControllerTest.php
+++ b/tests/Feature/User/ArticleControllerTest.php
@@ -84,4 +84,34 @@ class ArticleControllerTest extends TestCase
         $response = $this->post(route('user.article.store'));
         $response->assertRedirect(route('user.login'));
     }
+
+    /**
+     * @test
+     */
+    public function ログインしていれば自分の投稿の詳細を表示する()
+    {
+        $this->actingAs($this->user, 'users');
+
+        $article = Article::factory()->create(['user_id' => $this->user->id]); //自分の投稿、表示する
+        $otherArticle = Article::factory()->create(['user_id' => $this->user->id]); //自分の投稿、表示しない
+        $otherUserArticle = Article::factory()->create(); //他の人の投稿、表示しない
+
+        $response = $this->get(route('user.article.show', ['article' => $article->id]));
+
+        $response->assertSeeText($article->title);
+        $response->assertDontSeeText($otherArticle);
+        $response->assertDontSeeText($otherUserArticle);
+        $response->assertStatus(200);
+    }
+
+    /**
+     * @test
+     */
+    public function ログインしていない状態で投稿詳細を表示する場合ログイン画面へリダイレクトする()
+    {
+        $article = Article::factory()->create(['user_id' => $this->user->id]);
+
+        $response = $this->get(route('user.article.show', ['article' => $article->id]));
+        $response->assertRedirect(route('user.login'));
+    }
 }


### PR DESCRIPTION
## 今回のPRで行っていること
- 投稿詳細の表示機能実装
- 詳細表示のレスポンスのテスト作成

## UI変更点
### 新規追加
投稿詳細画面(タイトルと投稿日時、本文を表示)
<img width="959" alt="詳細画面スクショ" src="https://user-images.githubusercontent.com/69156872/200996901-2ebee302-aefe-4c7d-9fc0-8fedfeae87ff.png">
