### PR TITLE
投稿編集画面(ユーザー側)

### DIFF
--- a/app/Http/Controllers/User/ArticleController.php
+++ b/app/Http/Controllers/User/ArticleController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\User\Article\CreateRequest;
+use App\Http\Requests\User\Article\UpdateRequest;
 use App\Models\Article;
 use Illuminate\Support\Facades\Auth;
 
@@ -56,5 +57,29 @@ class ArticleController extends Controller
     public function show(int $id)
     {
         return view('user.article.show', ['article' => Article::find($id),]);
+    }
+
+    /**
+     * @param int $id
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function edit(int $id)
+    {
+        return view('user.article.edit', ['article' => Article::find($id)]);
+    }
+
+    /**
+     * @param UpdateRequest $request
+     * @param integer $id
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function update(UpdateRequest $request, int $id)
+    {
+        /** @var string $title */
+        $title = $request->title;
+        /** @var string $content */
+        $content = $request->content;
+        $this->article->updateArticle($title, $content, $id);
+        return to_route('user.article.index');
     }
 }

--- a/app/Http/Requests/User/Article/UpdateRequest.php
+++ b/app/Http/Requests/User/Article/UpdateRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\User\Article;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|max:50',
+            'content' => 'required|max:1000',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'title.required' => 'タイトルを入力して下さい',
+            'title.max' => 'タイトルは50文字以内で入力してください',
+            'content.required' => '本文を入力して下さい',
+            'content.max' => '本文は1000文字以内で入力してください',
+        ];
+    }
+}

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -37,6 +37,22 @@ class Article extends Model
         return $article;
     }
 
+    /**
+     * @param string $title
+     * @param string $content
+     * @param integer $id
+     * @return \App\Models\Article
+     */
+    public function updateArticle(string $title, string $content, int $id)
+    {
+        $article = $this::find($id);
+        $article->fill([
+            'title' => $title,
+            'content' => $content,
+        ])->save();
+        return $article;
+    }
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -1,1 +1,2 @@
-<textarea id={{ $id }} name={{ $name }} class="w-full h-72 whitespace-pre-wrap bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 resize-none leading-6 transition-colors duration-200 ease-in-out"></textarea>
+@props(['id','name','content'=>null])
+<textarea id={{ $id }} name={{ $name }} class="w-full h-72 whitespace-pre-wrap bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 resize-none leading-6 transition-colors duration-200 ease-in-out">{{ $content }}</textarea>

--- a/resources/views/user/article/edit.blade.php
+++ b/resources/views/user/article/edit.blade.php
@@ -1,0 +1,72 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            投稿編集画面
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+
+                    <form action="{{ route('user.article.update', ['article' => $article->id]) }}" method="POST">
+                        @csrf
+                        @method('put')
+                        <section class="text-gray-600 body-font relative w-full">
+                            <div class="py-8">
+                                <div class="lg:w-2/3 md:w-5/6 mx-auto">
+                                    <div class="flex flex-wrap -m-2">
+                                        <div class="p-2 w-full">
+                                            <div class="relative">
+                                                <div class="flex">
+                                                    <label for="title" class="leading-7 text-sm text-gray-600">タイトル</label>
+                                                    @if ($errors->has('title'))
+                                                        <ul>
+                                                            <li class="text-red-500 ml-4 mt-1 text-sm">{{ $errors->first('title') }}</li>
+                                                        </ul>
+                                                    @endif
+                                                </div>
+                                                @if(count($errors)>0)
+                                                    {{-- バリデーションがかかった場合は前に入力した内容を表示 --}}
+                                                    <x-text-input id="title" name="title" value="{{ old('title') }}" />
+                                                @else
+                                                    {{-- バリデーションがかかっていない時はコントローラから渡された内容を表示 --}}
+                                                    <x-text-input id="title" name="title" value="{{ $article->title }}" />
+                                                @endif
+                                            </div>
+                                        </div>
+                                        <div class="p-2 w-full">
+                                            <div class="relative">
+                                                <div class="flex">
+                                                    <label for="content"
+                                                        class="leading-7 text-sm text-gray-600">本文</label>
+                                                    @if ($errors->has('content'))
+                                                        <ul>
+                                                            <li class="text-red-500 ml-4 mt-1 text-sm">{{ $errors->first('content') }}</li>
+                                                        </ul>
+                                                    @endif
+                                                </div>
+                                                @if(count($errors)>0)
+                                                    {{-- バリデーションがかかった場合は前に入力した内容を表示 --}}
+                                                    <x-textarea id="content" name="content" content="{{ old('content') }}" />
+                                                @else
+                                                    {{-- バリデーションがかかっていない時はコントローラから渡された内容を表示 --}}
+                                                    <x-textarea id="content" name="content" content="{{ $article->content }}" />
+                                                @endif
+                                            </div>
+                                        </div>
+                                        <div class="p-2 w-full">
+                                            <x-submit-button title="更新する" class="bg-indigo-500 hover:bg-indigo-600" />
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+                    </form>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/user/article/edit.blade.php
+++ b/resources/views/user/article/edit.blade.php
@@ -27,13 +27,7 @@
                                                         </ul>
                                                     @endif
                                                 </div>
-                                                @if(count($errors)>0)
-                                                    {{-- バリデーションがかかった場合は前に入力した内容を表示 --}}
-                                                    <x-text-input id="title" name="title" value="{{ old('title') }}" />
-                                                @else
-                                                    {{-- バリデーションがかかっていない時はコントローラから渡された内容を表示 --}}
-                                                    <x-text-input id="title" name="title" value="{{ $article->title }}" />
-                                                @endif
+                                                <x-text-input id="title" name="title" value="{{ old('title') ?? $article->title }}" />
                                             </div>
                                         </div>
                                         <div class="p-2 w-full">
@@ -47,13 +41,7 @@
                                                         </ul>
                                                     @endif
                                                 </div>
-                                                @if(count($errors)>0)
-                                                    {{-- バリデーションがかかった場合は前に入力した内容を表示 --}}
-                                                    <x-textarea id="content" name="content" content="{{ old('content') }}" />
-                                                @else
-                                                    {{-- バリデーションがかかっていない時はコントローラから渡された内容を表示 --}}
-                                                    <x-textarea id="content" name="content" content="{{ $article->content }}" />
-                                                @endif
+                                                <x-textarea id="content" name="content" content="{{ old('content') ?? $article->content }}" />
                                             </div>
                                         </div>
                                         <div class="p-2 w-full">

--- a/resources/views/user/article/show.blade.php
+++ b/resources/views/user/article/show.blade.php
@@ -18,15 +18,20 @@
                                         <p class="text-sm mt-1">投稿日時 {{ $article->created_at }}</p>
                                         <div class="mt-4">
                                             {{-- 改行した状態で内容を表示するためエスケープ処理を無効化 --}}
-                                            <p class="leading-relaxed text-md mb-4">{!!nl2br(htmlspecialchars($article->content)) !!}</p>
+                                            <p class="leading-relaxed text-md mb-4">{!! nl2br(htmlspecialchars($article->content)) !!}</p>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </section>
-                    <div class="mx-auto w-32 mt-6">
-                        <x-anchor-button route="{{ route('user.article.index') }}" title="一覧へ戻る" class="bg-indigo-500 hover:bg-indigo-600" />
+                    <div class="flex justify-center">
+                        <div class="m-2 w-32 mt-6">
+                            <x-anchor-button route="{{ route('user.article.edit', ['article' => $article->id]) }}" title="編集する" class="bg-orange-500 hover:bg-orange-600" />
+                        </div>
+                        <div class="m-2 w-32 mt-6">
+                            <x-anchor-button route="{{ route('user.article.index') }}" title="一覧へ戻る" class="bg-indigo-500 hover:bg-indigo-600" />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/tests/Feature/User/ArticleControllerTest.php
+++ b/tests/Feature/User/ArticleControllerTest.php
@@ -114,4 +114,59 @@ class ArticleControllerTest extends TestCase
         $response = $this->get(route('user.article.show', ['article' => $article->id]));
         $response->assertRedirect(route('user.login'));
     }
+
+    /**
+     * @test
+     */
+    public function ログインしていれば投稿編集画面を表示する()
+    {
+        $this->actingAs($this->user, 'users');
+
+        $article = Article::factory()->create(); //表示する投稿
+        $otherArticle = Article::factory()->create(); //表示しない投稿
+
+        $response = $this->get(route('user.article.edit', ['article' => $article->id]));
+        $response->assertSeeText($article->content);
+        $response->assertDontSeeText($otherArticle->content);
+        $response->assertStatus(200);
+    }
+
+    /**
+     * @test
+     */
+    public function ログインしていない状態で投稿編集画面へアクセスした時ログイン画面へリダイレクトする()
+    {
+        $article = Article::factory()->create(); //表示する投稿
+
+        $response = $this->get(route('user.article.edit', ['article' => $article->id]));
+        $response->assertRedirect(route('user.login'));
+    }
+
+    /**
+     * @test
+     */
+    public function ログインしていれば投稿内容を更新する()
+    {
+        $this->actingAs($this->user, 'users');
+
+        $response = $this->put(route('user.article.update', [
+            'title' => 'タイトル',
+            'content' => '本文',
+            'article' => Article::factory()->create()->id,
+        ]));
+        $response->assertRedirect(route('user.article.index'));
+    }
+
+    /**
+     * @test
+     */
+    public function ログインしていない状態で投稿内容を更新した時ログイン画面へリダイレクトする()
+    {
+        $response = $this->put(route('user.article.update', [
+            'title' => 'タイトル',
+            'content' => '本文',
+            'article' => Article::factory()->create()->id,
+        ]));
+        $response->assertRedirect(route('user.login'));
+    }
 }

--- a/tests/Feature/User/ArticleControllerTest.php
+++ b/tests/Feature/User/ArticleControllerTest.php
@@ -109,9 +109,7 @@ class ArticleControllerTest extends TestCase
      */
     public function ログインしていない状態で投稿詳細を表示する場合ログイン画面へリダイレクトする()
     {
-        $article = Article::factory()->create(['user_id' => $this->user->id]);
-
-        $response = $this->get(route('user.article.show', ['article' => $article->id]));
+        $response = $this->get(route('user.article.show', ['article' => Article::factory()->create()->id]));
         $response->assertRedirect(route('user.login'));
     }
 
@@ -136,9 +134,7 @@ class ArticleControllerTest extends TestCase
      */
     public function ログインしていない状態で投稿編集画面へアクセスした時ログイン画面へリダイレクトする()
     {
-        $article = Article::factory()->create(); //表示する投稿
-
-        $response = $this->get(route('user.article.edit', ['article' => $article->id]));
+        $response = $this->get(route('user.article.edit', ['article' => Article::factory()->create()->id]));
         $response->assertRedirect(route('user.login'));
     }
 

--- a/tests/Unit/Models/ArticleTest.php
+++ b/tests/Unit/Models/ArticleTest.php
@@ -22,4 +22,12 @@ class ArticleTest extends TestCase
         $this->assertEquals('ほげほげ', $article->title);
         $this->assertEquals('ふがふが', $article->content);
     }
+
+    public function test_updateArticle()
+    {
+        $updateArticle = (new Article())->updateArticle('タイトル', '本文', Article::factory()->create()->id);
+
+        $this->assertEquals('タイトル', $updateArticle->title);
+        $this->assertEquals('本文', $updateArticle->content);
+    }
 }

--- a/tests/Unit/Requests/User/Article/UpdateRequestTest.php
+++ b/tests/Unit/Requests/User/Article/UpdateRequestTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit\Requests\User\Article;
+
+use App\Http\Requests\User\Article\UpdateRequest;
+use Faker\Factory;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class UpdateRequestTest extends TestCase
+{
+    /**
+     * 投稿作成のテストデータ
+     * @return array
+     */
+    public function dataProviderUpdate()
+    {
+        return [
+            '正常データ' => [
+                'data' => [
+                    'title' => 'ほげほげ',
+                    'content' => 'ふがふが',
+                ],
+                true,
+                'errors' => [],
+            ],
+            '空配列' => [
+                'data' => [],
+                false,
+                'errors' => [
+                    'title' => [
+                        'タイトルを入力して下さい'
+                    ],
+                    'content' => [
+                        '本文を入力して下さい'
+                    ],
+                ]
+            ],
+            '文字数上限' => [
+                'data' => [
+                    'title' => Factory::create()->realText(100),
+                    'content' => Factory::create()->realText(1200),
+                ],
+                false,
+                'errors' => [
+                    'title' => [
+                        'タイトルは50文字以内で入力してください'
+                    ],
+                    'content' => [
+                        '本文は1000文字以内で入力してください'
+                    ],
+                ]
+            ],
+        ];
+    }
+
+    protected function setup(): void
+    {
+        parent::setUp();
+        $this->updateRequest = new UpdateRequest();
+    }
+
+    /**
+     * 新規投稿の作成
+     * @test
+     * @param array $data
+     * @param boolean $expect
+     * @param array $errors
+     * @dataProvider dataProviderUpdate
+     * @return void
+     */
+    public function testUpdateValidation(array $data, bool $expect, array $errors): void
+    {
+        $validator = Validator::make($data, $this->updateRequest->rules(), $this->updateRequest->messages());
+        $this->assertEquals($expect, $validator->passes()); //バリデーションのチェックが通ったかどうか
+        $this->assertEquals($errors, $validator->errors()->getMessages()); //エラーメッセージテスト
+    }
+}

--- a/tests/Unit/Requests/User/Article/UpdateRequestTest.php
+++ b/tests/Unit/Requests/User/Article/UpdateRequestTest.php
@@ -10,7 +10,7 @@ use Tests\TestCase;
 class UpdateRequestTest extends TestCase
 {
     /**
-     * 投稿作成のテストデータ
+     * 投稿編集のテストデータ
      * @return array
      */
     public function dataProviderUpdate()
@@ -61,7 +61,7 @@ class UpdateRequestTest extends TestCase
     }
 
     /**
-     * 新規投稿の作成
+     * 投稿編集
      * @test
      * @param array $data
      * @param boolean $expect


### PR DESCRIPTION
## 今回のPRで行っていること
- 投稿編集機能の実装

## UI変更点
### 変更
投稿詳細画面：編集するボタンを追加しました
<img width="958" alt="image" src="https://user-images.githubusercontent.com/69156872/201253660-7f1c5a1c-770a-4df1-8ffd-d89557606025.png">

### 新規追加
投稿編集画面
<img width="950" alt="image" src="https://user-images.githubusercontent.com/69156872/201253712-fa946c9c-480f-4234-bcc3-2e52368d76a9.png">

