### PR TITLE
投稿詳細表示機能の実装（来訪者側）

### DIFF
--- a/app/Http/Controllers/Visitor/ArticleController.php
+++ b/app/Http/Controllers/Visitor/ArticleController.php
@@ -23,11 +23,8 @@ class ArticleController extends Controller
     public function show(int $id)
     {
         /** @var \App\Models\Article $article */
-        $article = Article::find($id);
+        $article = Article::with('user')->where('id', $id)->first();
 
-        /** @var \App\Models\User $user */
-        $user = User::find($article->user_id);
-
-        return view('visitor.article.show', ['article' => $article, 'userName' => $user->name]); //表示する投稿とその投稿の作成者の名前を取得
+        return view('visitor.article.show', ['article' => $article]);
     }
 }

--- a/app/Http/Controllers/Visitor/ArticleController.php
+++ b/app/Http/Controllers/Visitor/ArticleController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Visitor;
 
 use App\Http\Controllers\Controller;
 use App\Models\Article;
+use App\Models\User;
 
 class ArticleController extends Controller
 {
@@ -12,6 +13,21 @@ class ArticleController extends Controller
      */
     public function index()
     {
-        return view('visitor.index', ['articles' => Article::orderBy('created_at', 'desc')->paginate(20)]);
+        return view('visitor.article.index', ['articles' => Article::orderBy('created_at', 'desc')->paginate(20)]);
+    }
+
+    /**
+     * @param integer $id
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function show(int $id)
+    {
+        /** @var \App\Models\Article $article */
+        $article = Article::find($id);
+
+        /** @var \App\Models\User $user */
+        $user = User::find($article->user_id);
+
+        return view('visitor.article.show', ['article' => $article, 'userName' => $user->name]); //表示する投稿とその投稿の作成者の名前を取得
     }
 }

--- a/resources/views/visitor/article/index.blade.php
+++ b/resources/views/visitor/article/index.blade.php
@@ -12,7 +12,7 @@
                     @foreach($articles as $article)
                     <section class="text-gray-600 body-font overflow-hidden border-b-2 border-gray-200">
                         <div class="container px-10 pt-8 mx-auto">
-                            <a href="" class="-my-8">
+                            <a href="{{ route('visitor.article.show',['article'=>$article->id]) }}" class="-my-8">
                                 <div class="pt-2 pb-9 flex items-center w-full">
                                     <div class="md:flex-grow w-11/12">
                                         <div class="mb-2">

--- a/resources/views/visitor/article/show.blade.php
+++ b/resources/views/visitor/article/show.blade.php
@@ -1,0 +1,40 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            記事詳細画面
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <section class="text-gray-600 body-font">
+                        <div class="container mx-auto flex flex-col">
+                            <div class="lg:w-full mx-auto">
+                                <div class="flex flex-col sm:flex-row mt-3">
+                                    <div class="w-full sm:pl-8 border-gray-200 sm:border-t-0 border-t mt-4 pt-4 sm:mt-0 text-center sm:text-left">
+                                        <div class="mb-2">
+                                            <p>{{ $userName }}</p>
+                                        </div>
+                                        <h1 class="font-bold text-3xl text-black">{{ $article->title }}</h1>
+                                        <p class="text-sm mt-1">投稿日時 {{ $article->created_at }}</p>
+                                        <div class="mt-4">
+                                            {{-- 改行した状態で内容を表示するため改行のみエスケープ処理を無効化 --}}
+                                            <p class="leading-relaxed text-md mb-4">{!! nl2br(htmlspecialchars($article->content)) !!}</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                    <div class="flex justify-center">
+                        <div class="m-2 w-32 mt-6">
+                            <x-anchor-button route="{{ route('visitor.article.index') }}" title="一覧へ戻る" class="bg-indigo-500 hover:bg-indigo-600" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/visitor/article/show.blade.php
+++ b/resources/views/visitor/article/show.blade.php
@@ -15,7 +15,7 @@
                                 <div class="flex flex-col sm:flex-row mt-3">
                                     <div class="w-full sm:pl-8 border-gray-200 sm:border-t-0 border-t mt-4 pt-4 sm:mt-0 text-center sm:text-left">
                                         <div class="mb-2">
-                                            <p>{{ $userName }}</p>
+                                            <p>{{ $article->user->name }}</p>
                                         </div>
                                         <h1 class="font-bold text-3xl text-black">{{ $article->title }}</h1>
                                         <p class="text-sm mt-1">投稿日時 {{ $article->created_at }}</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,4 +14,6 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', [ArticleController::class,'index'])->name('visitor.article.index');
+Route::get('/', [ArticleController::class, 'index'])->name('visitor.article.index');
+
+Route::get('/show/{article}', [ArticleController::class, 'show'])->name('visitor.article.show');

--- a/tests/Feature/Visitor/ArticleControllerTest.php
+++ b/tests/Feature/Visitor/ArticleControllerTest.php
@@ -26,23 +26,24 @@ class ArticleControllerTest extends TestCase
     }
 
     /**
+     * 投稿詳細表示のレスポンス・表示したい投稿と投稿者名が表示されているか
      * @test
      */
     public function 投稿詳細を表示()
     {
-        $user = User::factory()->create(); //表示する投稿の作成者
-        $otherUser = User::factory()->create(); //表示しない投稿の作成者
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
 
-        $article = Article::factory()->create(['user_id' => $user->id]); //表示する投稿
-        $otherArticle = Article::factory()->create(['user_id' => $otherUser->id]); //表示しない投稿
+        $article = Article::factory()->create(['user_id' => $user->id]);
+        $otherArticle = Article::factory()->create(['user_id' => $otherUser->id]);
 
-        $response = $this->get(route('visitor.article.show', ['article' => $article->id, 'userName' => $user->name]));
+        $response = $this->get(route('visitor.article.show', ['article' => $article->id]));
 
-        $response->assertSeeText($article->title); //表示したい投稿のタイトルが表示されているか
-        $response->assertSeeText($user->name); //表示したい投稿の作成者の名前が表示されているか
+        $response->assertSeeText($article->title);
+        $response->assertSeeText($user->name);
 
-        $response->assertDontSeeText($otherArticle->title); //表示しない投稿のタイトルが表示されていないか
-        $response->assertDontSeeText($otherUser->name); //表示しない投稿の作成者の名前が表示されていないか
+        $response->assertDontSeeText($otherArticle->title);
+        $response->assertDontSeeText($otherUser->name);
         $response->assertStatus(200);
     }
 }

--- a/tests/Feature/Visitor/ArticleControllerTest.php
+++ b/tests/Feature/Visitor/ArticleControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Visitor;
 
 use App\Models\Article;
+use App\Models\User;
 use Tests\TestCase;
 
 class ArticleControllerTest extends TestCase
@@ -17,10 +18,31 @@ class ArticleControllerTest extends TestCase
      */
     public function 投稿一覧を表示()
     {
-        $article=Article::factory()->create();
-        $response=$this->get(route('visitor.article.index'));
+        $article = Article::factory()->create();
+        $response = $this->get(route('visitor.article.index'));
 
         $response->assertSeeText($article->title);
+        $response->assertStatus(200);
+    }
+
+    /**
+     * @test
+     */
+    public function 投稿詳細を表示()
+    {
+        $user = User::factory()->create(); //表示する投稿の作成者
+        $otherUser = User::factory()->create(); //表示しない投稿の作成者
+
+        $article = Article::factory()->create(['user_id' => $user->id]); //表示する投稿
+        $otherArticle = Article::factory()->create(['user_id' => $otherUser->id]); //表示しない投稿
+
+        $response = $this->get(route('visitor.article.show', ['article' => $article->id, 'userName' => $user->name]));
+
+        $response->assertSeeText($article->title); //表示したい投稿のタイトルが表示されているか
+        $response->assertSeeText($user->name); //表示したい投稿の作成者の名前が表示されているか
+
+        $response->assertDontSeeText($otherArticle->title); //表示しない投稿のタイトルが表示されていないか
+        $response->assertDontSeeText($otherUser->name); //表示しない投稿の作成者の名前が表示されていないか
         $response->assertStatus(200);
     }
 }


### PR DESCRIPTION
## 今回のPRで行っていること
- 投稿詳細表示機能(来訪者側)の実装

## UI変更点
### 新規追加
投稿詳細画面
<img width="944" alt="image" src="https://user-images.githubusercontent.com/69156872/201823251-0a083c1e-3876-4db1-87ba-f536aa98c669.png">

