### PR TITLE
ユーザーの投稿一覧表示機能の実装（管理者側）

### DIFF
--- a/app/Http/Controllers/Admin/ArticleController.php
+++ b/app/Http/Controllers/Admin/ArticleController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Article;
+
+class ArticleController extends Controller
+{
+    /**
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function index()
+    {
+        return view('admin.article.index', ['articles' => Article::with('user')->orderBy('created_at', 'desc')->paginate(20)]);
+    }
+}

--- a/app/Http/Controllers/Visitor/ArticleController.php
+++ b/app/Http/Controllers/Visitor/ArticleController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Visitor;
 
 use App\Http\Controllers\Controller;
 use App\Models\Article;
-use App\Models\User;
 
 class ArticleController extends Controller
 {

--- a/app/Http/Controllers/Visitor/ArticleController.php
+++ b/app/Http/Controllers/Visitor/ArticleController.php
@@ -12,7 +12,7 @@ class ArticleController extends Controller
      */
     public function index()
     {
-        return view('visitor.article.index', ['articles' => Article::orderBy('created_at', 'desc')->paginate(20)]);
+        return view('visitor.article.index', ['articles' => Article::with('user')->orderBy('created_at', 'desc')->paginate(20)]);
     }
 
     /**

--- a/resources/views/admin/article/index.blade.php
+++ b/resources/views/admin/article/index.blade.php
@@ -22,6 +22,15 @@
                                         <span class="text-gray-500 text-sm">投稿日 {{\Carbon\Carbon::parse($article->created_at)}}</span>
                                         <p class="leading-relaxed mt-4">{{Str::limit($article->content, 200, '...') }}</p>
                                     </div>
+                                    <div class="w-1/12 text-center pl-8">
+                                        <form onsubmit="return confirm('投稿を削除してもよろしいですか？')" action="" method="post" >
+                                            @csrf
+                                            @method('delete')
+                                            <button type="submit">
+                                                <x-delete-icon class=""/>
+                                            </button>
+                                        </form>
+                                    </div>
                                 </div>
                             </a>
                         </div>

--- a/resources/views/admin/article/index.blade.php
+++ b/resources/views/admin/article/index.blade.php
@@ -1,0 +1,37 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            最新の投稿
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="px-6 pb-6 bg-white border-b border-gray-200">
+                    @foreach($articles as $article)
+                    <section class="text-gray-600 body-font overflow-hidden border-b-2 border-gray-200">
+                        <div class="container px-10 pt-8 mx-auto">
+                            <a href="" class="-my-8">
+                                <div class="pt-2 pb-9 flex items-center w-full">
+                                    <div class="md:flex-grow w-11/12">
+                                        <div class="mb-2">
+                                            <p>{{ $article->user->name }}</p>
+                                        </div>
+                                        <h2 class="text-2xl font-medium text-gray-900 title-font">{{ $article->title }}</h2>
+                                        <span class="text-gray-500 text-sm">投稿日 {{\Carbon\Carbon::parse($article->created_at)}}</span>
+                                        <p class="leading-relaxed mt-4">{{Str::limit($article->content, 200, '...') }}</p>
+                                    </div>
+                                </div>
+                            </a>
+                        </div>
+                    </section>
+                    @endforeach
+                </div>
+                <div class="my-3 mx-6">
+                    {{ $articles->links() }}
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/layouts/admin-navigation.blade.php
+++ b/resources/views/layouts/admin-navigation.blade.php
@@ -18,6 +18,9 @@
                     <x-nav-link :href="route('admin.user.index')" :active="request()->routeIs('admin.user.index')">
                         ユーザー一覧
                     </x-nav-link>
+                    <x-nav-link :href="route('admin.article.index')" :active="request()->routeIs('admin.article.index')">
+                        ユーザー投稿一覧
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -78,6 +81,9 @@
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('admin.user.index')" :active="request()->routeIs('admin.user.index')">
                 ユーザー一覧
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('admin.article.index')" :active="request()->routeIs('admin.article.index')">
+                ユーザー投稿一覧
             </x-responsive-nav-link>
         </div>
 

--- a/resources/views/layouts/admin-navigation.blade.php
+++ b/resources/views/layouts/admin-navigation.blade.php
@@ -19,7 +19,7 @@
                         ユーザー一覧
                     </x-nav-link>
                     <x-nav-link :href="route('admin.article.index')" :active="request()->routeIs('admin.article.index')">
-                        ユーザー投稿一覧
+                        投稿一覧
                     </x-nav-link>
                 </div>
             </div>
@@ -83,7 +83,7 @@
                 ユーザー一覧
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('admin.article.index')" :active="request()->routeIs('admin.article.index')">
-                ユーザー投稿一覧
+                投稿一覧
             </x-responsive-nav-link>
         </div>
 

--- a/resources/views/visitor/article/index.blade.php
+++ b/resources/views/visitor/article/index.blade.php
@@ -16,7 +16,7 @@
                                 <div class="pt-2 pb-9 flex items-center w-full">
                                     <div class="md:flex-grow w-11/12">
                                         <div class="mb-2">
-                                            <p>{{ App\Models\User::find($article->user_id)->name }}</p>
+                                            <p>{{ $article->user->name }}</p>
                                         </div>
                                         <h2 class="text-2xl font-medium text-gray-900 title-font">{{ $article->title }}</h2>
                                         <span class="text-gray-500 text-sm">投稿日 {{\Carbon\Carbon::parse($article->created_at)}}</span>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Admin\ArticleController;
 use App\Http\Controllers\Admin\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\Admin\Auth\RegisteredUserController;
 use Illuminate\Support\Facades\Route;
@@ -15,6 +16,7 @@ use App\Http\Controllers\Admin\UserController;
 | contains the "web" middleware group. Now create something great!
 |
 */
+
 Route::middleware('guest')->group(function () {
     Route::get('register', [RegisteredUserController::class, 'create'])->name('register');
 
@@ -31,6 +33,8 @@ Route::middleware('auth:admins')->group(function () {
     })->name('dashboard');
 
     Route::resource('user', UserController::class);
+
+    Route::resource('article', ArticleController::class);
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])->name('logout');
 });

--- a/tests/Feature/Admin/ArticleControllerTest.php
+++ b/tests/Feature/Admin/ArticleControllerTest.php
@@ -23,8 +23,7 @@ class ArticleControllerTest extends TestCase
     {
         $this->actingAs($this->admin, 'admins');
 
-        $user = User::factory()->create();
-        $article = Article::factory()->create(['user_id' => $user->id]);
+        $article = Article::factory()->create();
 
         $response = $this->get(route('admin.article.index'));
 

--- a/tests/Feature/Admin/ArticleControllerTest.php
+++ b/tests/Feature/Admin/ArticleControllerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use Tests\TestCase;
+use App\Models\Article;
+use App\Models\User;
+use App\Models\Admin;
+
+class ArticleControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = Admin::factory()->create();
+    }
+
+    /**
+     * ユーザーの投稿と投稿者名の一覧が表示できているか
+     * @test
+     */
+    public function ログインしていればユーザーの投稿一覧を表示()
+    {
+        $this->actingAs($this->admin, 'admins');
+
+        $user = User::factory()->create();
+        $article = Article::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->get(route('admin.article.index'));
+
+        $response->assertSeeText($article->title);
+        $response->assertSeeText($article->user->name);
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/Admin/ArticleControllerTest.php
+++ b/tests/Feature/Admin/ArticleControllerTest.php
@@ -32,4 +32,13 @@ class ArticleControllerTest extends TestCase
         $response->assertSeeText($article->user->name);
         $response->assertStatus(200);
     }
+
+    /**
+     * @test
+     */
+    public function ログインしていない状態でユーザーの投稿一覧を表示する時ログイン画面へリダイレクト()
+    {
+        $response = $this->get(route('admin.article.index'));
+        $response->assertRedirect(route('admin.login'));
+    }
 }

--- a/tests/Feature/Visitor/ArticleControllerTest.php
+++ b/tests/Feature/Visitor/ArticleControllerTest.php
@@ -14,14 +14,18 @@ class ArticleControllerTest extends TestCase
     }
 
     /**
+     * 投稿一覧表示で表示したい投稿のタイトルと投稿者名が表示されているか
      * @test
      */
     public function 投稿一覧を表示()
     {
-        $article = Article::factory()->create();
+        $user=User::factory()->create();
+        $article = Article::factory()->create(['user_id'=>$user->id]);
+
         $response = $this->get(route('visitor.article.index'));
 
         $response->assertSeeText($article->title);
+        $response->assertSeeText($article->user->name);
         $response->assertStatus(200);
     }
 

--- a/tests/Feature/Visitor/ArticleControllerTest.php
+++ b/tests/Feature/Visitor/ArticleControllerTest.php
@@ -19,8 +19,7 @@ class ArticleControllerTest extends TestCase
      */
     public function 投稿一覧を表示()
     {
-        $user=User::factory()->create();
-        $article = Article::factory()->create(['user_id'=>$user->id]);
+        $article = Article::factory()->create();
 
         $response = $this->get(route('visitor.article.index'));
 


### PR DESCRIPTION
## 今回のPRで行っていること
- ユーザーの投稿一覧表示

## 迷っていること
pushしてから気づいたのですが、投稿一覧を表示するルーティングが`admin.article.index`になっているのですがアドミンの記事ではないのにこのルーティング名はちょっと混乱するのではないかと思い、`admin.user-article.index`に変更しようか迷っています。

## UI変更点
### 新規追加
ユーザーの投稿一覧画面：welcomeページで表示している一覧画面と同じです。
<img width="944" alt="image" src="https://user-images.githubusercontent.com/69156872/202105719-c42a9876-a024-463d-b4e3-105037a4b01c.png">
