### PR TITLE
投稿詳細表示機能の実装（管理者側）

### DIFF
--- a/app/Http/Controllers/Admin/ArticleController.php
+++ b/app/Http/Controllers/Admin/ArticleController.php
@@ -8,10 +8,24 @@ use App\Models\Article;
 class ArticleController extends Controller
 {
     /**
+     * 投稿一覧を表示
      * @return \Illuminate\Contracts\View\View
      */
     public function index()
     {
         return view('admin.article.index', ['articles' => Article::with('user')->orderBy('created_at', 'desc')->paginate(20)]);
+    }
+
+    /**
+     * 投稿詳細を表示
+     * @param integer $id
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function show(int $id)
+    {
+        /** @var \App\Models\Article $article */
+        $article = Article::with('user')->where('id', $id)->first();
+
+        return view('admin.article.show', ['article' => $article]);
     }
 }

--- a/resources/views/admin/article/index.blade.php
+++ b/resources/views/admin/article/index.blade.php
@@ -12,7 +12,7 @@
                     @foreach($articles as $article)
                     <section class="text-gray-600 body-font overflow-hidden border-b-2 border-gray-200">
                         <div class="container px-10 pt-8 mx-auto">
-                            <a href="" class="-my-8">
+                            <a href="{{ route('admin.article.show',['article'=>$article->id]) }}" class="-my-8">
                                 <div class="pt-2 pb-9 flex items-center w-full">
                                     <div class="md:flex-grow w-11/12">
                                         <div class="mb-2">

--- a/resources/views/admin/article/show.blade.php
+++ b/resources/views/admin/article/show.blade.php
@@ -1,0 +1,40 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            記事詳細画面
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <section class="text-gray-600 body-font">
+                        <div class="container mx-auto flex flex-col">
+                            <div class="lg:w-full mx-auto">
+                                <div class="flex flex-col sm:flex-row mt-3">
+                                    <div class="w-full sm:pl-8 border-gray-200 sm:border-t-0 border-t mt-4 pt-4 sm:mt-0 text-center sm:text-left">
+                                        <div class="mb-2">
+                                            <p>{{ $article->user->name }}</p>
+                                        </div>
+                                        <h1 class="font-bold text-3xl text-black">{{ $article->title }}</h1>
+                                        <p class="text-sm mt-1">投稿日時 {{ $article->created_at }}</p>
+                                        <div class="mt-4">
+                                            {{-- 改行した状態で内容を表示するため改行のみエスケープ処理を無効化 --}}
+                                            <p class="leading-relaxed text-md mb-4">{!! nl2br(htmlspecialchars($article->content)) !!}</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                    <div class="flex justify-center">
+                        <div class="m-2 w-32 mt-6">
+                            <x-anchor-button route="{{ route('admin.article.index') }}" title="一覧へ戻る" class="bg-indigo-500 hover:bg-indigo-600" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/tests/Feature/Admin/ArticleControllerTest.php
+++ b/tests/Feature/Admin/ArticleControllerTest.php
@@ -40,4 +40,34 @@ class ArticleControllerTest extends TestCase
         $response = $this->get(route('admin.article.index'));
         $response->assertRedirect(route('admin.login'));
     }
+
+    /**
+     * 表示したい投稿・投稿者名が表示されているか、他の投稿が表示されていないか
+     * @test
+     */
+    public function ログインしていればユーザーの投稿詳細表示()
+    {
+        $this->actingAs($this->admin, 'admins');
+
+        $article = Article::factory()->create();
+        $otherArticle = Article::factory()->create();
+
+        $response = $this->get(route('admin.article.show', ['article' => $article->id]));
+
+        $response->assertSeeText($article->title);
+        $response->assertSeeText($article->user->name);
+
+        $response->assertDontSeeText($otherArticle->title);
+        $response->assertDontSeeText($otherArticle->user->name);
+        $response->assertStatus(200);
+    }
+
+    /**
+     * @test
+     */
+    public function ログインしていない状態で投稿詳細画面にアクセスした時ログイン画面へリダイレクトする()
+    {
+        $response = $this->get(route('admin.article.show', ['article' => Article::factory()->create()->id]));
+        $response->assertRedirect(route('admin.login'));
+    }
 }


### PR DESCRIPTION
## 今回のPRで行っていること
- ユーザーの投稿詳細表示機能（管理者側）の実装

## UI変更点
### 新規追加
投稿詳細画面：来訪者側の投稿詳細画面とUIは全く同じです
<img width="732" alt="image" src="https://user-images.githubusercontent.com/69156872/202704283-5ed9a951-a50a-4ab5-9f45-be6bc97f1f49.png">

