### PR TITLE
タグ一覧表示（管理者側）

### DIFF
--- a/app/Http/Controllers/Admin/TagController.php
+++ b/app/Http/Controllers/Admin/TagController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Tag;
+
+class TagController extends Controller
+{
+    /**
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function index()
+    {
+        return view('admin.tag.index', ['tags' => Tag::paginate(20)]);
+    }
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Tag extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Tag>
+ */
+class TagFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'name' => fake()->word(),
+        ];
+    }
+}

--- a/database/migrations/2022_11_20_233210_create_tags_table.php
+++ b/database/migrations/2022_11_20_233210_create_tags_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,7 @@ class DatabaseSeeder extends Seeder
             AdminSeeder::class,
             UserSeeder::class,
             ArticleSeeder::class,
+            TagSeeder::class,
         ]);
     }
 }

--- a/database/seeders/TagSeeder.php
+++ b/database/seeders/TagSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class TagSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('tags')->insert([
+            'name' => 'ほげほげ',
+        ]);
+    }
+}

--- a/resources/views/admin/tag/index.blade.php
+++ b/resources/views/admin/tag/index.blade.php
@@ -1,0 +1,80 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            タグ
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-2 bg-white border-b border-gray-200">
+                    <div class="px-3 mx-auto w-5/6 mt-4">
+                        <h1 class="text-2xl font-bold">タグ登録</h1>
+                    </div>
+
+                    <section class="text-gray-600 body-font relative mb-8">
+                        <div class="container px-5 pt-3 mx-auto">
+                            <div class="w-5/6 mx-auto">
+                                <div class="flex flex-wrap -m-2">
+                                    <div class="p-2 w-1/3">
+                                        <div class="relative">
+                                            <label for="name" class="leading-7 text-sm text-gray-600">タグ名</label>
+                                            <input type="text" id="name" name="name"
+                                                class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                                        </div>
+                                    </div>
+                                    <div class="p-2 w-1/6 mt-7">
+                                        <x-submit-button title="登録" class="bg-indigo-500 hover:bg-indigo-600" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <div class="px-3 mx-auto w-5/6 mt-8 mb-5">
+                        <h1 class="text-2xl font-bold">タグ一覧</h1>
+                    </div>
+
+                    <section class="text-gray-600 body-font">
+                        <div class="container px-3 pb-12 w-full">
+                            <div class="w-2/3 overflow-auto mx-auto">
+                                <table class="table-auto w-full text-left whitespace-no-wrap">
+                                    <thead>
+                                        <tr>
+                                            <th
+                                                class="text-center w-1/2 px-2 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100 rounded-tl rounded-bl">
+                                                タグ名
+                                            </th>
+                                            <th
+                                                class="w-1/6 px-2 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">
+                                            </th>
+                                            <th
+                                                class="w-1/6 px-2 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    @foreach ($tags as $tag)
+                                        <tbody class="mt-2">
+                                            <tr>
+                                                <td class="px-2 py-3 text-center text-sm">{{ $tag->name }}</td>
+                                                <td class="py-3 w-1/6">
+                                                    <x-anchor-button route="" title="編集"
+                                                        class="bg-green-500 hover:bg-green-600 w-2/3" />
+                                                </td>
+                                                <td class="py-3 w-1/6">
+                                                    <x-submit-button title="削除"
+                                                        class="bg-red-500 hover:bg-red-600" />
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    @endforeach
+                                </table>
+                            </div>
+                        </div>
+                    </section>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/layouts/admin-navigation.blade.php
+++ b/resources/views/layouts/admin-navigation.blade.php
@@ -21,6 +21,9 @@
                     <x-nav-link :href="route('admin.article.index')" :active="request()->routeIs('admin.article.index')">
                         投稿一覧
                     </x-nav-link>
+                    <x-nav-link :href="route('admin.tag.index')" :active="request()->routeIs('admin.tag.index')">
+                        タグ
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -84,6 +87,9 @@
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('admin.article.index')" :active="request()->routeIs('admin.article.index')">
                 投稿一覧
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('admin.tag.index')" :active="request()->routeIs('admin.tag.index')">
+                タグ
             </x-responsive-nav-link>
         </div>
 

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Admin\ArticleController;
 use App\Http\Controllers\Admin\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\Admin\Auth\RegisteredUserController;
+use App\Http\Controllers\Admin\TagController;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Admin\UserController;
 
@@ -35,6 +36,8 @@ Route::middleware('auth:admins')->group(function () {
     Route::resource('user', UserController::class);
 
     Route::resource('article', ArticleController::class);
+
+    Route::resource('tag', TagController::class);
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])->name('logout');
 });

--- a/tests/Feature/Admin/TagControllerTest.php
+++ b/tests/Feature/Admin/TagControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Tag;
+use App\Models\Admin;
+use Tests\TestCase;
+
+class TagControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = Admin::factory()->create();
+        $this->tag = Tag::factory()->create();
+    }
+
+    /**
+     * タグ名が表示されているかどうか
+     * @test
+     */
+    public function ログインしていればタグ一覧を表示()
+    {
+        $this->actingAs($this->admin, 'admins');
+
+        $response = $this->get(route('admin.tag.index'));
+        $response->assertStatus(200);
+        $response->assertSeeText($this->tag->name);
+    }
+
+    /**
+     * @test
+     */
+    public function ログインしていない状態でタグ一覧を表示する時ログイン画面へリダイレクトする()
+    {
+        $response = $this->get(route('admin.tag.index'));
+        $response->assertRedirect(route('admin.login'));
+    }
+}


### PR DESCRIPTION
## 今回のPRで行っていること
- タグ一覧表示機能の実装
- タグ一覧画面のUI：登録、編集、削除の処理は今後のPRで

## 次回のPRで行うこと
- タグの登録：できれば非同期でやってみます

## UI変更点
### 新規追加
タグ一覧画面
<img width="958" alt="image" src="https://user-images.githubusercontent.com/69156872/202969684-3ef0da7d-c605-413e-a02e-3e77aa21754c.png">

