### PR TITLE
タグ編集（管理者側）

### DIFF
--- a/app/Http/Controllers/Admin/TagController.php
+++ b/app/Http/Controllers/Admin/TagController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\Tag\StoreRequest;
+use App\Http\Requests\Admin\Tag\UpdateRequest;
 use App\Models\Tag;
 
 class TagController extends Controller
@@ -33,6 +34,29 @@ class TagController extends Controller
         $name = $request->input('name');
         $this->tag->storeTag($name);
 
+        return to_route('admin.tag.index');
+    }
+
+    /**
+     * @param integer $id
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function edit(int $id)
+    {
+        return view('admin.tag.edit', ['tag' => Tag::find($id)]);
+    }
+
+    /**
+     * @param UpdateRequest $request
+     * @param integer $id
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function update(UpdateRequest $request, int $id)
+    {
+        /** @var string $name */
+        $name = $request->name;
+
+        $this->tag->updateTag($name, $id);
         return to_route('admin.tag.index');
     }
 }

--- a/app/Http/Requests/Admin/Tag/UpdateRequest.php
+++ b/app/Http/Requests/Admin/Tag/UpdateRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\Admin\Tag;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required|max:15',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'name.required' => 'タグ名を入力して下さい',
+            'name.max' => 'タグ名は15文字以内で入力してください',
+        ];
+    }
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -31,4 +31,19 @@ class Tag extends Model
         ]);
         return $tag;
     }
+
+    /**
+     * @param string $name
+     * @param integer $id
+     * @return \App\Models\Tag
+     */
+    public function updateTag(string $name, int $id)
+    {
+        $tag = $this::find($id);
+
+        $tag->fill([
+            'name' => $name,
+        ])->save();
+        return $tag;
+    }
 }

--- a/resources/views/admin/tag/edit.blade.php
+++ b/resources/views/admin/tag/edit.blade.php
@@ -1,0 +1,46 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            タグ編集画面
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+
+                    <form action="{{ route('admin.tag.update', ['tag' => $tag->id]) }}" method="POST">
+                        @csrf
+                        @method('put')
+                        <section class="text-gray-600 body-font relative w-full">
+                            <div class="py-5">
+                                <div class="lg:w-2/3 md:w-5/6 mx-auto">
+                                    <div class="flex flex-wrap justify-center -m-2">
+                                        <div class="p-2 w-full mx-auto">
+                                            <div class="relative w-2/3 mx-auto">
+                                                <div class="flex">
+                                                    <label for="name" class="leading-7 text-sm text-gray-600">タグ名</label>
+                                                    @if ($errors->has('name'))
+                                                        <ul>
+                                                            <li class="text-red-500 ml-4 mt-1 text-sm">{{ $errors->first('name') }}</li>
+                                                        </ul>
+                                                    @endif
+                                                </div>
+                                                <x-text-input class="" id="name" name="name" value="{{ old('name') ?? $tag->name }}" />
+                                            </div>
+                                        </div>
+                                        <div class="p-2 w-full">
+                                            <x-submit-button title="更新する" class="bg-indigo-500 hover:bg-indigo-600" />
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+                    </form>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/tag/index.blade.php
+++ b/resources/views/admin/tag/index.blade.php
@@ -18,8 +18,8 @@
                         <section class="text-gray-600 body-font relative mb-8">
                             <div class="container px-5 pt-3 mx-auto">
                                 <div class="w-5/6 mx-auto">
-                                    <div class="flex flex-wrap -m-2">
-                                        <div class="p-2 w-1/3">
+                                    <div class="flex flex-wrap justify-center -m-2">
+                                        <div class="p-2 w-1/2">
                                             <div class="relative">
                                                 <div class="flex">
                                                     <label for="name"
@@ -56,28 +56,29 @@
                                     <thead>
                                         <tr>
                                             <th
-                                                class="text-center w-1/2 px-2 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100 rounded-tl rounded-bl">
+                                                class="text-center w-1/3 px-2 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-200 rounded-tl rounded-bl">
                                                 タグ名
                                             </th>
                                             <th
-                                                class="w-1/6 px-2 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">
+                                                class="w-1/12 px-2 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-200">
                                             </th>
                                             <th
-                                                class="w-1/6 px-2 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">
+                                                class="w-1/12 px-2 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-200">
                                             </th>
                                         </tr>
                                     </thead>
                                     @foreach ($tags as $tag)
-                                        <tbody class="mt-2">
+                                        <tbody class="mt-2 bg-slate-100">
                                             <tr>
                                                 <td class="px-2 py-3 text-center text-sm">{{ $tag->name }}</td>
-                                                <td class="py-3 w-1/6">
-                                                    <x-anchor-button route="" title="編集"
-                                                        class="bg-green-500 hover:bg-green-600 w-2/3" />
+                                                <td class="py-3 w-1/12">
+                                                    <x-anchor-button
+                                                        route="{{ route('admin.tag.edit', ['tag' => $tag->id]) }}"
+                                                        title="編集" class="bg-green-500 hover:bg-green-600 w-5/6" />
                                                 </td>
-                                                <td class="py-3 w-1/6">
+                                                <td class="py-3 w-1/12">
                                                     <x-submit-button title="削除"
-                                                        class="bg-red-500 hover:bg-red-600" />
+                                                        class="bg-red-500 hover:bg-red-600 w-5/6" />
                                                 </td>
                                             </tr>
                                         </tbody>

--- a/tests/Feature/Admin/TagControllerTest.php
+++ b/tests/Feature/Admin/TagControllerTest.php
@@ -60,4 +60,51 @@ class TagControllerTest extends TestCase
         ]));
         $response->assertRedirect(route('admin.login'));
     }
+
+    /**
+     * @test
+     */
+    public function ログインしていればタグ編集画面を表示する()
+    {
+        $this->actingAs($this->admin, 'admins');
+
+        $response = $this->get(route('admin.tag.edit', ['tag' => $this->tag]));
+        $response->assertStatus(200);
+    }
+
+    /**
+     * @test
+     */
+    public function ログインしていない状態でタグ編集画面へアクセスした時ログイン画面へリダイレクトされる()
+    {
+        $response = $this->get(route('admin.tag.edit', ['tag' => $this->tag->id]));
+        $response->assertRedirect(route('admin.login'));
+    }
+
+    /**
+     * 更新した後タグ一覧画面へリダイレクトしているか
+     * @test
+     */
+    public function ログインしていればタグ内容を更新する()
+    {
+        $this->actingAs($this->admin, 'admins');
+
+        $response = $this->put(route('admin.tag.update', [
+            'name' => 'ほげほげ',
+            'tag' => $this->tag->id,
+        ]));
+        $response->assertRedirect(route('admin.tag.index'));
+    }
+
+    /**
+     * @test
+     */
+    public function ログインしていない状態でタグ内容を更新した時ログイン画面へリダイレクトする()
+    {
+        $response = $this->put(route('admin.tag.update', [
+            'name' => 'ほげほげ',
+            'tag' => $this->tag->id,
+        ]));
+        $response->assertRedirect(route('admin.login'));
+    }
 }

--- a/tests/Unit/Models/TagTest.php
+++ b/tests/Unit/Models/TagTest.php
@@ -7,10 +7,25 @@ use Tests\TestCase;
 
 class TagTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tag = Tag::factory()->create([
+            'name' => 'ほげほげ',
+        ]);
+    }
+
     public function test_storeTag()
     {
         $tag = (new Tag())->storeTag('ほげほげ');
 
         $this->assertEquals('ほげほげ', $tag->name);
+    }
+
+    public function test_updateTag()
+    {
+        $updateTag = (new Tag())->updateTag('ふがふが', $this->tag->id);
+
+        $this->assertEquals('ふがふが', $updateTag->name);
     }
 }

--- a/tests/Unit/Requests/Admin/Tag/UpdateRequestTest.php
+++ b/tests/Unit/Requests/Admin/Tag/UpdateRequestTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\Requests\Admin\Tag;
+
+use Tests\TestCase;
+use Faker\Factory;
+use App\Http\Requests\Admin\Tag\UpdateRequest;
+use Illuminate\Support\Facades\Validator;
+
+class UpdateRequestTest extends TestCase
+{
+    /**
+     * ユーザー情報更新のテストデータ
+     * @return array
+     */
+    public function dataProviderUpdate()
+    {
+        return [
+            '正常データ' => [
+                'data' => [
+                    'name' => 'ほげほげ',
+                ],
+                true,
+                'errors' => [],
+            ],
+            '空配列' => [
+                'data' => [],
+                false,
+                'errors' => [
+                    'name' => [
+                        'タグ名を入力して下さい'
+                    ],
+                ]
+            ],
+            '文字数超過' => [
+                'data' => [
+                    'name' => Factory::create()->realText(30),
+                ],
+                false,
+                'errors' => [
+                    'name' => [
+                        'タグ名は15文字以内で入力してください'
+                    ],
+                ],
+            ]
+        ];
+    }
+
+    protected function setup(): void
+    {
+        parent::setUp();
+        $this->updateRequest = new UpdateRequest();
+    }
+
+    /**
+     * タグ更新
+     * @test
+     * @param array $data
+     * @param boolean $expect
+     * @param array $errors
+     * @return void
+     * @dataProvider dataProviderUpdate
+     */
+    public function testUpdateValidation(array $data, bool $expect, array $errors): void
+    {
+        $validator = Validator::make($data, $this->updateRequest->rules(), $this->updateRequest->messages());
+        $this->assertEquals($expect, $validator->passes());
+        $this->assertEquals($errors, $validator->errors()->getMessages());
+    }
+}


### PR DESCRIPTION
## 今回のPRで行っていること
- タグ編集の実装
- タグ一覧画面のUIを一部修正

## UI変更点
### 新規追加
タグ編集画面：少し見栄えが悪いですがフォームで編集画面を作成しました
<img width="958" alt="image" src="https://user-images.githubusercontent.com/69156872/203219482-401e28cd-2a8e-46fc-9d36-5935d9a98ec8.png">

### 変更点
タグ一覧画面：レイアウトとテーブルの色などを変更しました
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/69156872/203219037-ff63e677-8f3a-4be3-bc46-cdab0068629e.png">
