### PR TITLE
投稿作成にタグ登録を追加（ユーザー側）

### DIFF
--- a/app/Http/Controllers/User/ArticleController.php
+++ b/app/Http/Controllers/User/ArticleController.php
@@ -47,10 +47,10 @@ class ArticleController extends Controller
         $title = $request->title;
         /** @var string $content */
         $content = $request->content;
-        /** @var array $tag */
-        $tag = $request->tag;
+        /** @var array $tags */
+        $tags = $request->tags;
 
-        $this->article->storeArticle($userId, $title, $content, $tag);
+        $this->article->storeArticle($userId, $title, $content, $tags);
 
         return to_route('user.article.index');
     }

--- a/app/Http/Controllers/User/ArticleController.php
+++ b/app/Http/Controllers/User/ArticleController.php
@@ -47,8 +47,11 @@ class ArticleController extends Controller
         $title = $request->title;
         /** @var string $content */
         $content = $request->content;
+        /** @var array $tag */
+        $tag = $request->tag;
 
-        $this->article->storeArticle($userId, $title, $content);
+        $this->article->storeArticle($userId, $title, $content, $tag);
+
         return to_route('user.article.index');
     }
 

--- a/app/Http/Controllers/User/ArticleController.php
+++ b/app/Http/Controllers/User/ArticleController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\User\Article\CreateRequest;
 use App\Http\Requests\User\Article\UpdateRequest;
 use App\Models\Article;
+use App\Models\Tag;
 use Illuminate\Support\Facades\Auth;
 
 class ArticleController extends Controller
@@ -31,7 +32,7 @@ class ArticleController extends Controller
      */
     public function create()
     {
-        return view('user.article.create');
+        return view('user.article.create', ['tags' => Tag::all()]);
     }
 
     /**

--- a/app/Http/Requests/User/Article/CreateRequest.php
+++ b/app/Http/Requests/User/Article/CreateRequest.php
@@ -26,7 +26,7 @@ class CreateRequest extends FormRequest
         return [
             'title' => 'required|max:50',
             'content' => 'required|max:1000',
-            'tag' => 'required|max:5',
+            'tags' => 'required|max:5',
         ];
     }
 
@@ -37,8 +37,8 @@ class CreateRequest extends FormRequest
             'title.max' => 'タイトルは50文字以内で入力してください',
             'content.required' => '本文を入力して下さい',
             'content.max' => '本文は1000文字以内で入力してください',
-            'tag.required' => 'タグは1つ以上選択して下さい',
-            'tag.max' => 'タグ数は5つ以下にして下さい',
+            'tags.required' => 'タグは1つ以上選択して下さい',
+            'tags.max' => 'タグ数は5つ以下にして下さい',
         ];
     }
 }

--- a/app/Http/Requests/User/Article/CreateRequest.php
+++ b/app/Http/Requests/User/Article/CreateRequest.php
@@ -26,6 +26,7 @@ class CreateRequest extends FormRequest
         return [
             'title' => 'required|max:50',
             'content' => 'required|max:1000',
+            'tag' => 'required|max:5',
         ];
     }
 
@@ -36,6 +37,8 @@ class CreateRequest extends FormRequest
             'title.max' => 'タイトルは50文字以内で入力してください',
             'content.required' => '本文を入力して下さい',
             'content.max' => '本文は1000文字以内で入力してください',
+            'tag.required' => 'タグは1つ以上選択して下さい',
+            'tag.max' => 'タグ数は5つ以下にして下さい',
         ];
     }
 }

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -29,14 +29,16 @@ class Article extends Model
      * @param int $userId
      * @param string $title
      * @param string $content
+     * @param array $tag
      */
-    public function storeArticle(int $userId, string $title, string $content)
+    public function storeArticle(int $userId, string $title, string $content, array $tag)
     {
         $article = $this->create([
             'user_id' => $userId,
             'title' => $title,
             'content' => $content,
         ]);
+        $article->tags()->sync($tag);
         return $article;
     }
 

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Article extends Model
@@ -67,5 +68,10 @@ class Article extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class);
     }
 }

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -23,6 +23,16 @@ class Article extends Model
         'title',
         'content',
     ];
+    
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class);
+    }
 
     /**
      * @return \App\Models\Article
@@ -65,15 +75,5 @@ class Article extends Model
     public function destroyArticle(Article $article)
     {
         $article->delete();
-    }
-
-    public function user(): BelongsTo
-    {
-        return $this->belongsTo(User::class);
-    }
-
-    public function tags(): BelongsToMany
-    {
-        return $this->belongsToMany(Tag::class);
     }
 }

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -23,7 +23,7 @@ class Article extends Model
         'title',
         'content',
     ];
-    
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
@@ -39,16 +39,16 @@ class Article extends Model
      * @param int $userId
      * @param string $title
      * @param string $content
-     * @param array $tag
+     * @param array $tags
      */
-    public function storeArticle(int $userId, string $title, string $content, array $tag)
+    public function storeArticle(int $userId, string $title, string $content, array $tags)
     {
         $article = $this->create([
             'user_id' => $userId,
             'title' => $title,
             'content' => $content,
         ]);
-        $article->tags()->sync($tag);
+        $article->tags()->sync($tags);
         return $article;
     }
 

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Tag extends Model
@@ -54,5 +55,10 @@ class Tag extends Model
     public function destroyTag(int $id)
     {
         $this::find($id)->delete();
+    }
+
+    public function articles(): BelongsToMany
+    {
+        return $this->belongsToMany(Article::class);
     }
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -20,6 +20,11 @@ class Tag extends Model
     protected $fillable = [
         'name',
     ];
+    
+    public function articles(): BelongsToMany
+    {
+        return $this->belongsToMany(Article::class);
+    }
 
     /**
      * @param string $name
@@ -55,10 +60,5 @@ class Tag extends Model
     public function destroyTag(int $id)
     {
         $this::find($id)->delete();
-    }
-
-    public function articles(): BelongsToMany
-    {
-        return $this->belongsToMany(Article::class);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,6 +26,11 @@ class User extends Authenticatable
         'email',
         'password',
     ];
+    
+    public function articles(): HasMany
+    {
+        return $this->hasMany(Article::class);
+    }
 
     /**
      * The attributes that should be hidden for serialization.
@@ -45,11 +50,6 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
-
-    public function articles(): HasMany
-    {
-        return $this->hasMany(Article::class);
-    }
 
     /**
      * @return \App\Models\User

--- a/database/migrations/2022_11_22_141124_create_article_tag_table.php
+++ b/database/migrations/2022_11_22_141124_create_article_tag_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\Article;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Psy\CodeCleaner\FunctionReturnInWriteContextPass;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('article_tag', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('article_id')->constrained()->onDelete('cascade');
+            $table->foreignId('tag_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('article_tag');
+    }
+};

--- a/database/migrations/2022_11_22_141124_create_article_tag_table.php
+++ b/database/migrations/2022_11_22_141124_create_article_tag_table.php
@@ -1,10 +1,8 @@
 <?php
 
-use App\Models\Article;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Psy\CodeCleaner\FunctionReturnInWriteContextPass;
 
 return new class extends Migration
 {
@@ -19,7 +17,6 @@ return new class extends Migration
             $table->id();
             $table->foreignId('article_id')->constrained()->onDelete('cascade');
             $table->foreignId('tag_id')->constrained()->onDelete('cascade');
-            $table->timestamps();
         });
     }
 

--- a/resources/views/components/tag-checkbox.blade.php
+++ b/resources/views/components/tag-checkbox.blade.php
@@ -1,4 +1,7 @@
 <div class="flex mt-2">
-    <input type="checkbox" id="tag" name="tag[]" class="w-5 h-5 text-blue-600 bg-gray-100 rounded border-gray-300 mt-2" value="{{ $value }}">
-    <label for="checkbox" class="pt-2 ml-1 mr-3 w-full text-sm text-gray-900 dark:text-gray-300">{{ $name }}</label>
+    <input type="checkbox" id="tags" name="tags[]"
+        class="w-5 h-5 text-blue-600 bg-gray-100 rounded border-gray-300 mt-2" value="{{ $id }}"
+        @if (is_array(old('tags')) && in_array($id, old('tags'))) checked @endif />
+    <label for="checkbox"
+        class="pt-2 ml-1 mr-3 w-full text-sm text-gray-900 dark:text-gray-300">{{ $name }}</label>
 </div>

--- a/resources/views/components/tag-checkbox.blade.php
+++ b/resources/views/components/tag-checkbox.blade.php
@@ -1,0 +1,4 @@
+<div class="flex mt-2">
+    <input type="checkbox" id="tag" name="tag[]" class="w-5 h-5 text-blue-600 bg-gray-100 rounded border-gray-300 mt-2" value="{{ $value }}">
+    <label for="checkbox" class="pt-2 ml-1 mr-3 w-full text-sm text-gray-900 dark:text-gray-300">{{ $name }}</label>
+</div>

--- a/resources/views/user/article/create.blade.php
+++ b/resources/views/user/article/create.blade.php
@@ -8,38 +8,64 @@
     <div class="py-12">
         <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 bg-white border-b border-gray-200">
+                <div class="py-6 px-16 bg-white border-b border-gray-200">
 
                     <form action="{{ route('user.article.store') }}" method="POST">
                         @csrf
                         <section class="text-gray-600 body-font relative w-full">
                             <div class="py-8">
-                                <div class="lg:w-2/3 md:w-5/6 mx-auto">
-                                    <div class="flex flex-wrap -m-2">
+                                <div class="lg:w-full md:w-full mx-auto">
+                                    <div class="-m-2 w-full">
                                         <div class="p-2 w-full">
                                             <div class="relative">
                                                 <div class="flex">
-                                                    <label for="title" class="leading-7 text-sm text-gray-600">タイトル</label>
-                                                    @if ($errors->has('title'))
+                                                    <label for="tag"
+                                                        class="leading-7 text-sm text-gray-600">タグ選択</label>
+                                                    @if ($errors->has('tag'))
                                                         <ul>
-                                                            <li class="text-red-500 ml-4 mt-1 text-sm">{{$errors->first('title')}}</li>
+                                                            <li class="text-red-500 ml-4 mt-1 text-sm">
+                                                                {{ $errors->first('tag') }}</li>
                                                         </ul>
                                                     @endif
                                                 </div>
-                                                <x-text-input id="title" name="title" value="{{ old('title') }}"/>
+                                                <div class="flex flex-wrap">
+                                                    @foreach ($tags as $tag)
+                                                        <x-tag-checkbox name="{{ $tag->name }}"
+                                                            value="{{ $tag->id }}" />
+                                                    @endforeach
+                                                </div>
                                             </div>
                                         </div>
                                         <div class="p-2 w-full">
                                             <div class="relative">
                                                 <div class="flex">
-                                                    <label for="content" class="leading-7 text-sm text-gray-600">本文</label>
-                                                    @if ($errors->has('content'))
+                                                    <label for="title"
+                                                        class="leading-7 text-sm text-gray-600">タイトル</label>
+                                                    @if ($errors->has('title'))
                                                         <ul>
-                                                            <li class="text-red-500 ml-4 mt-1 text-sm">{{$errors->first('content')}}</li>
+                                                            <li class="text-red-500 ml-4 mt-1 text-sm">
+                                                                {{ $errors->first('title') }}</li>
                                                         </ul>
                                                     @endif
                                                 </div>
-                                                <x-textarea id="content" name="content">{{ old('content') }}</x-textarea>
+                                                <x-text-input id="title" name="title"
+                                                    value="{{ old('title') }}" />
+                                            </div>
+                                        </div>
+                                        <div class="p-2 w-full">
+                                            <div class="relative">
+                                                <div class="flex">
+                                                    <label for="content"
+                                                        class="leading-7 text-sm text-gray-600">本文</label>
+                                                    @if ($errors->has('content'))
+                                                        <ul>
+                                                            <li class="text-red-500 ml-4 mt-1 text-sm">
+                                                                {{ $errors->first('content') }}</li>
+                                                        </ul>
+                                                    @endif
+                                                </div>
+                                                <x-textarea id="content" name="content">{{ old('content') }}
+                                                </x-textarea>
                                             </div>
                                         </div>
                                         <div class="p-2 w-full">

--- a/resources/views/user/article/create.blade.php
+++ b/resources/views/user/article/create.blade.php
@@ -21,17 +21,17 @@
                                                 <div class="flex">
                                                     <label for="tag"
                                                         class="leading-7 text-sm text-gray-600">タグ選択</label>
-                                                    @if ($errors->has('tag'))
+                                                    @if ($errors->has('tags'))
                                                         <ul>
                                                             <li class="text-red-500 ml-4 mt-1 text-sm">
-                                                                {{ $errors->first('tag') }}</li>
+                                                                {{ $errors->first('tags') }}</li>
                                                         </ul>
                                                     @endif
                                                 </div>
                                                 <div class="flex flex-wrap">
                                                     @foreach ($tags as $tag)
                                                         <x-tag-checkbox name="{{ $tag->name }}"
-                                                            value="{{ $tag->id }}" />
+                                                            id="{{ $tag->id }}" />
                                                     @endforeach
                                                 </div>
                                             </div>

--- a/resources/views/user/article/create.blade.php
+++ b/resources/views/user/article/create.blade.php
@@ -64,7 +64,8 @@
                                                         </ul>
                                                     @endif
                                                 </div>
-                                                <x-textarea id="content" name="content">{{ old('content') }}
+                                                <x-textarea id="content" name="content"
+                                                    content="{{ old('content') }}">
                                                 </x-textarea>
                                             </div>
                                         </div>

--- a/tests/Feature/User/ArticleControllerTest.php
+++ b/tests/Feature/User/ArticleControllerTest.php
@@ -74,7 +74,7 @@ class ArticleControllerTest extends TestCase
         $response = $this->post(route('user.article.store', [
             'title' => "ほげほげ",
             'content' => "ふがふが",
-            'tag' => [0 => $tag->id],
+            'tags' => [$tag->id],
         ]));
         $response->assertRedirect(route('user.article.index'));
     }

--- a/tests/Feature/User/ArticleControllerTest.php
+++ b/tests/Feature/User/ArticleControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Article;
+use App\Models\Tag;
 use Tests\TestCase;
 use App\Models\User;
 
@@ -68,10 +69,12 @@ class ArticleControllerTest extends TestCase
     public function ログインしていれば新規投稿内容の保存を行う()
     {
         $this->actingAs($this->user, 'users');
+        $tag = Tag::factory()->create();
 
         $response = $this->post(route('user.article.store', [
             'title' => "ほげほげ",
             'content' => "ふがふが",
+            'tag' => [0 => $tag->id],
         ]));
         $response->assertRedirect(route('user.article.index'));
     }

--- a/tests/Unit/Models/ArticleTest.php
+++ b/tests/Unit/Models/ArticleTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Models;
 
 use App\Models\Article;
+use App\Models\Tag;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -16,11 +17,13 @@ class ArticleTest extends TestCase
 
     public function test_storeArticle()
     {
-        $article = (new Article())->storeArticle($this->user->id, 'ほげほげ', 'ふがふが');
+        $tag = Tag::factory()->create();
+        $article = (new Article())->storeArticle($this->user->id, 'ほげほげ', 'ふがふが', [0 => $tag->id]);
 
         $this->assertEquals($this->user->id, $article->user_id);
         $this->assertEquals('ほげほげ', $article->title);
         $this->assertEquals('ふがふが', $article->content);
+        $this->assertEquals($tag->id, $article->tags->first()->id);
     }
 
     public function test_updateArticle()

--- a/tests/Unit/Models/ArticleTest.php
+++ b/tests/Unit/Models/ArticleTest.php
@@ -18,7 +18,7 @@ class ArticleTest extends TestCase
     public function test_storeArticle()
     {
         $tag = Tag::factory()->create();
-        $article = (new Article())->storeArticle($this->user->id, 'ほげほげ', 'ふがふが', [0 => $tag->id]);
+        $article = (new Article())->storeArticle($this->user->id, 'ほげほげ', 'ふがふが', [$tag->id]);
 
         $this->assertEquals($this->user->id, $article->user_id);
         $this->assertEquals('ほげほげ', $article->title);

--- a/tests/Unit/Requests/User/Article/CreateRequestTest.php
+++ b/tests/Unit/Requests/User/Article/CreateRequestTest.php
@@ -20,7 +20,7 @@ class CreateRequestTest extends TestCase
                 'data' => [
                     'title' => 'ほげほげ',
                     'content' => 'ふがふが',
-                    'tag' => [0 => 1],
+                    'tags' => [1],
                 ],
                 true,
                 'errors' => [],
@@ -35,7 +35,7 @@ class CreateRequestTest extends TestCase
                     'content' => [
                         '本文を入力して下さい'
                     ],
-                    'tag' => [
+                    'tags' => [
                         'タグは1つ以上選択して下さい'
                     ]
                 ]
@@ -44,7 +44,7 @@ class CreateRequestTest extends TestCase
                 'data' => [
                     'title' => Factory::create()->realText(100),
                     'content' => Factory::create()->realText(1200),
-                    'tag' => [0 => 1],
+                    'tags' => [1],
                 ],
                 false,
                 'errors' => [
@@ -60,18 +60,11 @@ class CreateRequestTest extends TestCase
                 'data' => [
                     'title' => 'ほげほげ',
                     'content' => 'ふがふが',
-                    'tag' => [
-                        0 => 1,
-                        1 => 2,
-                        2 => 3,
-                        3 => 4,
-                        4 => 5,
-                        5 => 6,
-                    ],
+                    'tags' => [1, 2, 3, 4, 5, 6],
                 ],
                 false,
                 'errors' => [
-                    'tag' => [
+                    'tags' => [
                         'タグ数は5つ以下にして下さい'
                     ]
                 ]
@@ -98,7 +91,7 @@ class CreateRequestTest extends TestCase
     public function testCreateValidation(array $data, bool $expect, array $errors): void
     {
         $validator = Validator::make($data, $this->createRequest->rules(), $this->createRequest->messages());
-        $this->assertEquals($expect, $validator->passes()); //バリデーションのチェックが通ったかどうか
-        $this->assertEquals($errors, $validator->errors()->getMessages()); //エラーメッセージテスト
+        $this->assertEquals($expect, $validator->passes());
+        $this->assertEquals($errors, $validator->errors()->getMessages());
     }
 }

--- a/tests/Unit/Requests/User/Article/CreateRequestTest.php
+++ b/tests/Unit/Requests/User/Article/CreateRequestTest.php
@@ -20,6 +20,7 @@ class CreateRequestTest extends TestCase
                 'data' => [
                     'title' => 'ほげほげ',
                     'content' => 'ふがふが',
+                    'tag' => [0 => 1],
                 ],
                 true,
                 'errors' => [],
@@ -34,12 +35,16 @@ class CreateRequestTest extends TestCase
                     'content' => [
                         '本文を入力して下さい'
                     ],
+                    'tag' => [
+                        'タグは1つ以上選択して下さい'
+                    ]
                 ]
             ],
             '文字数上限' => [
                 'data' => [
                     'title' => Factory::create()->realText(100),
                     'content' => Factory::create()->realText(1200),
+                    'tag' => [0 => 1],
                 ],
                 false,
                 'errors' => [
@@ -51,6 +56,27 @@ class CreateRequestTest extends TestCase
                     ],
                 ]
             ],
+            'タグ数上限' => [
+                'data' => [
+                    'title' => 'ほげほげ',
+                    'content' => 'ふがふが',
+                    'tag' => [
+                        0 => 1,
+                        1 => 2,
+                        2 => 3,
+                        3 => 4,
+                        4 => 5,
+                        5 => 6,
+                    ],
+                ],
+                false,
+                'errors' => [
+                    'tag' => [
+                        'タグ数は5つ以下にして下さい'
+                    ]
+                ]
+            ]
+
         ];
     }
 


### PR DESCRIPTION
## 今回のPRで行っていること
- 投稿を作成する時にタグを登録できるように修正（複数選択可）
- タグ登録のみ実装を行っていて、タグを用いた機能は未実装

## 次回以降のPRで行うこと
- 投稿詳細画面で登録したタグを表示
- 投稿のタグ検索（投稿一覧画面）

## UI変更点
投稿作成画面：画像は30件のタグを表示
<img width="1033" alt="image" src="https://user-images.githubusercontent.com/69156872/203267825-e6b3ccfe-4cb4-45c1-9b0a-d6290351983c.png">

