### PR TITLE
投稿のタグ表示（すべてのログイン状態）

### DIFF
--- a/app/Http/Controllers/Admin/ArticleController.php
+++ b/app/Http/Controllers/Admin/ArticleController.php
@@ -20,7 +20,7 @@ class ArticleController extends Controller
      */
     public function index()
     {
-        return view('admin.article.index', ['articles' => Article::with('user')->orderBy('created_at', 'desc')->paginate(20)]);
+        return view('admin.article.index', ['articles' => Article::with(['user', 'tags'])->orderBy('created_at', 'desc')->paginate(20)]);
     }
 
     /**
@@ -31,7 +31,7 @@ class ArticleController extends Controller
     public function show(int $id)
     {
         /** @var \App\Models\Article $article */
-        $article = Article::with('user')->where('id', $id)->first();
+        $article = Article::with(['user', 'tags'])->where('id', $id)->first();
 
         return view('admin.article.show', ['article' => $article]);
     }

--- a/app/Http/Controllers/User/ArticleController.php
+++ b/app/Http/Controllers/User/ArticleController.php
@@ -24,7 +24,7 @@ class ArticleController extends Controller
      */
     public function index()
     {
-        return view('user.article.index', ['articles' => Article::where('user_id', Auth::id())->with('tags')->get()]);
+        return view('user.article.index', ['articles' => Article::where('user_id', Auth::id())->orderBy('created_at','desc')->with('tags')->get()]);
     }
 
     /**

--- a/app/Http/Controllers/User/ArticleController.php
+++ b/app/Http/Controllers/User/ArticleController.php
@@ -24,7 +24,7 @@ class ArticleController extends Controller
      */
     public function index()
     {
-        return view('user.article.index', ['articles' => Article::where('user_id', Auth::id())->get()]);
+        return view('user.article.index', ['articles' => Article::where('user_id', Auth::id())->with('tags')->get()]);
     }
 
     /**
@@ -61,7 +61,7 @@ class ArticleController extends Controller
      */
     public function show(Article $article)
     {
-        return view('user.article.show', ['article' => $article]);
+        return view('user.article.show', ['article' => $article::where('id', $article->id)->with('tags')->first()]);
     }
 
     /**

--- a/app/Http/Controllers/Visitor/ArticleController.php
+++ b/app/Http/Controllers/Visitor/ArticleController.php
@@ -12,7 +12,7 @@ class ArticleController extends Controller
      */
     public function index()
     {
-        return view('visitor.article.index', ['articles' => Article::with('user')->orderBy('created_at', 'desc')->paginate(20)]);
+        return view('visitor.article.index', ['articles' => Article::with(['user', 'tags'])->orderBy('created_at', 'desc')->paginate(20)]);
     }
 
     /**
@@ -22,7 +22,7 @@ class ArticleController extends Controller
     public function show(int $id)
     {
         /** @var \App\Models\Article $article */
-        $article = Article::with('user')->where('id', $id)->first();
+        $article = Article::with(['tags', 'user'])->where('id', $id)->first();
 
         return view('visitor.article.show', ['article' => $article]);
     }

--- a/resources/views/admin/article/index.blade.php
+++ b/resources/views/admin/article/index.blade.php
@@ -19,6 +19,11 @@
                                             <p>{{ $article->user->name }}</p>
                                         </div>
                                         <h2 class="text-2xl font-medium text-gray-900 title-font">{{ $article->title }}</h2>
+                                        <div class="flex mb-2 mt-1">
+                                            @foreach($article->tags as $tag)
+                                                <p class="mr-3 text-sm text-blue-600">#{{ $tag->name }}</p>
+                                            @endforeach
+                                        </div>
                                         <span class="text-gray-500 text-sm">投稿日 {{\Carbon\Carbon::parse($article->created_at)}}</span>
                                         <p class="leading-relaxed mt-4">{{Str::limit($article->content, 200, '...') }}</p>
                                     </div>

--- a/resources/views/admin/article/show.blade.php
+++ b/resources/views/admin/article/show.blade.php
@@ -18,6 +18,11 @@
                                             <p>{{ $article->user->name }}</p>
                                         </div>
                                         <h1 class="font-bold text-3xl text-black">{{ $article->title }}</h1>
+                                        <div class="flex mb-2 mt-1">
+                                            @foreach($article->tags as $tag)
+                                                <p class="mr-3 text-sm text-blue-600">#{{ $tag->name }}</p>
+                                            @endforeach
+                                        </div>
                                         <p class="text-sm mt-1">投稿日時 {{ $article->created_at }}</p>
                                         <div class="mt-4">
                                             {{-- 改行した状態で内容を表示するため改行のみエスケープ処理を無効化 --}}

--- a/resources/views/user/article/index.blade.php
+++ b/resources/views/user/article/index.blade.php
@@ -17,6 +17,11 @@
                                 <div class="pt-2 pb-9 flex items-center w-full">
                                     <div class="md:flex-grow w-11/12">
                                         <h2 class="text-2xl font-medium text-gray-900 title-font">{{ $article->title }}</h2>
+                                        <div class="flex mb-2 mt-1">
+                                            @foreach($article->tags as $tag)
+                                                <p class="mr-3 text-sm text-blue-600">#{{ $tag->name }}</p>
+                                            @endforeach
+                                        </div>
                                         <span class="text-gray-500 text-sm">投稿日 {{\Carbon\Carbon::parse($article->created_at)}}</span>
                                         <p class="leading-relaxed mt-4">{{Str::limit($article->content, 200, '...') }}</p>
                                     </div>

--- a/resources/views/user/article/show.blade.php
+++ b/resources/views/user/article/show.blade.php
@@ -15,6 +15,11 @@
                                 <div class="flex flex-col sm:flex-row mt-10">
                                     <div class="w-full sm:pl-8 border-gray-200 sm:border-t-0 border-t mt-4 pt-4 sm:mt-0 text-center sm:text-left">
                                         <h1 class="font-bold text-3xl text-black">{{ $article->title }}</h1>
+                                        <div class="flex mb-2 mt-1">
+                                            @foreach($article->tags as $tag)
+                                                <p class="mr-3 text-sm text-blue-600">#{{ $tag->name }}</p>
+                                            @endforeach
+                                        </div>
                                         <p class="text-sm mt-1">投稿日時 {{ $article->created_at }}</p>
                                         <div class="mt-4">
                                             {{-- 改行した状態で内容を表示するため改行のみエスケープ処理を無効化 --}}

--- a/resources/views/visitor/article/index.blade.php
+++ b/resources/views/visitor/article/index.blade.php
@@ -19,6 +19,11 @@
                                             <p>{{ $article->user->name }}</p>
                                         </div>
                                         <h2 class="text-2xl font-medium text-gray-900 title-font">{{ $article->title }}</h2>
+                                        <div class="flex mb-2 mt-1">
+                                            @foreach($article->tags as $tag)
+                                                <p class="mr-3 text-sm text-blue-600">#{{ $tag->name }}</p>
+                                            @endforeach
+                                        </div>
                                         <span class="text-gray-500 text-sm">投稿日 {{\Carbon\Carbon::parse($article->created_at)}}</span>
                                         <p class="leading-relaxed mt-4">{{Str::limit($article->content, 200, '...') }}</p>
                                     </div>

--- a/resources/views/visitor/article/show.blade.php
+++ b/resources/views/visitor/article/show.blade.php
@@ -18,6 +18,11 @@
                                             <p>{{ $article->user->name }}</p>
                                         </div>
                                         <h1 class="font-bold text-3xl text-black">{{ $article->title }}</h1>
+                                        <div class="flex mb-2 mt-1">
+                                            @foreach($article->tags as $tag)
+                                                <p class="mr-3 text-sm text-blue-600">#{{ $tag->name }}</p>
+                                            @endforeach
+                                        </div>
                                         <p class="text-sm mt-1">投稿日時 {{ $article->created_at }}</p>
                                         <div class="mt-4">
                                             {{-- 改行した状態で内容を表示するため改行のみエスケープ処理を無効化 --}}

--- a/tests/Feature/Admin/ArticleControllerTest.php
+++ b/tests/Feature/Admin/ArticleControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Admin;
 use Tests\TestCase;
 use App\Models\Article;
 use App\Models\Admin;
+use App\Models\Tag;
 
 class ArticleControllerTest extends TestCase
 {
@@ -12,10 +13,11 @@ class ArticleControllerTest extends TestCase
     {
         parent::setUp();
         $this->admin = Admin::factory()->create();
+        $this->tag = Tag::factory()->create();
     }
 
     /**
-     * ユーザーの投稿と投稿者名の一覧が表示できているか
+     * 投稿のタイトル・投稿者名・タグが表示できているか
      * @test
      */
     public function ログインしていればユーザーの投稿一覧を表示()
@@ -23,11 +25,13 @@ class ArticleControllerTest extends TestCase
         $this->actingAs($this->admin, 'admins');
 
         $article = Article::factory()->create();
+        $article->tags()->sync([$this->tag->id]);
 
         $response = $this->get(route('admin.article.index'));
 
         $response->assertSeeText($article->title);
         $response->assertSeeText($article->user->name);
+        $response->assertSeeText($this->tag->name);
         $response->assertStatus(200);
     }
 
@@ -41,7 +45,7 @@ class ArticleControllerTest extends TestCase
     }
 
     /**
-     * 表示したい投稿・投稿者名が表示されているか、他の投稿が表示されていないか
+     * 表示したい投稿のタイトル・投稿者名・タグが表示されているか、他の投稿・投稿者名が表示されていないか
      * @test
      */
     public function ログインしていればユーザーの投稿詳細表示()
@@ -51,10 +55,13 @@ class ArticleControllerTest extends TestCase
         $article = Article::factory()->create();
         $otherArticle = Article::factory()->create();
 
+        $article->tags()->sync([$this->tag->id]);
+
         $response = $this->get(route('admin.article.show', ['article' => $article->id]));
 
         $response->assertSeeText($article->title);
         $response->assertSeeText($article->user->name);
+        $response->assertSeeText($this->tag->name);
 
         $response->assertDontSeeText($otherArticle->title);
         $response->assertDontSeeText($otherArticle->user->name);

--- a/tests/Feature/Visitor/ArticleControllerTest.php
+++ b/tests/Feature/Visitor/ArticleControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Visitor;
 
 use App\Models\Article;
+use App\Models\Tag;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -11,25 +12,30 @@ class ArticleControllerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+        $this->tag = Tag::factory()->create();
     }
 
     /**
-     * 投稿一覧表示で表示したい投稿のタイトルと投稿者名が表示されているか
+     * 投稿のタイトルと投稿者名、タグが表示されているか
      * @test
      */
     public function 投稿一覧を表示()
     {
         $article = Article::factory()->create();
 
+        $article->tags()->sync([$this->tag->id]);
+
         $response = $this->get(route('visitor.article.index'));
 
         $response->assertSeeText($article->title);
         $response->assertSeeText($article->user->name);
+        $response->assertSeeText($this->tag->name);
+
         $response->assertStatus(200);
     }
 
     /**
-     * 投稿詳細表示のレスポンス・表示したい投稿と投稿者名が表示されているか
+     * 表示したい投稿・投稿者名・タグが表示されているか、他の投稿・投稿者名が表示されていないか
      * @test
      */
     public function 投稿詳細を表示()
@@ -40,10 +46,14 @@ class ArticleControllerTest extends TestCase
         $article = Article::factory()->create(['user_id' => $user->id]);
         $otherArticle = Article::factory()->create(['user_id' => $otherUser->id]);
 
+        $otherTag = Tag::factory()->create();
+        $article->tags()->sync([$this->tag->id]);
+
         $response = $this->get(route('visitor.article.show', ['article' => $article->id]));
 
         $response->assertSeeText($article->title);
         $response->assertSeeText($user->name);
+        $response->assertSeeText($this->tag->name);
 
         $response->assertDontSeeText($otherArticle->title);
         $response->assertDontSeeText($otherUser->name);


### PR DESCRIPTION
## 今回のPRで行っていること
- 一覧画面、詳細画面で投稿に紐づいたタグを表示（すべてのログイン状態）

## 次回のPRで行うこと
- 投稿のタグ編集

## UI変更点
投稿一覧画面
<img width="944" alt="一覧画面" src="https://user-images.githubusercontent.com/69156872/204198943-505130bf-fa57-4ec2-89f0-320f29b5d5c8.png">

投稿詳細画面
<img width="953" alt="詳細画面" src="https://user-images.githubusercontent.com/69156872/204199039-becf994b-5bc6-4c47-b5c2-a440b66be5f9.png">


